### PR TITLE
Add retrieval of ingresses from k8s apiserver

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	const (
-		defaultAPIServer  = "https://10.254.0.1:443"
+		defaultAPIServer  = "https://kubernetes:443"
 		defaultCaCertFile = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 		defaultTokenFile  = "/run/secrets/kubernetes.io/serviceaccount/token"
 	)

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -78,7 +78,7 @@ func createK8sClient() k8s.Client {
 func readFile(path string) []byte {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		log.Errorf("Unable to read %s: %v", caCertFile, err)
+		log.Errorf("Unable to read %s: %v", path, err)
 		os.Exit(-1)
 	}
 	return data

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -4,25 +4,82 @@ import (
 	"os"
 	"os/signal"
 	//
+	"flag"
+
+	"io/ioutil"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/sky-uk/feed/ingress"
 	"github.com/sky-uk/feed/k8s"
 )
 
+var (
+	apiServer  string
+	caCertFile string
+	tokenFile  string
+	debug      bool
+)
+
+func init() {
+	const (
+		defaultAPIServer  = "https://10.254.0.1:443"
+		defaultCaCertFile = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+		defaultTokenFile  = "/run/secrets/kubernetes.io/serviceaccount/token"
+	)
+
+	flag.StringVar(&apiServer, "apiserver", defaultAPIServer, "Kubernetes API server URL")
+	flag.StringVar(&caCertFile, "cacertfile", defaultCaCertFile, "file containing kubernetes ca certificate")
+	flag.StringVar(&tokenFile, "tokenfile", defaultTokenFile, "file containing kubernetes client authentication token")
+	flag.BoolVar(&debug, "debug", false, "enable debug logging")
+}
+
 func main() {
+	flag.Parse()
+
+	configureLogging()
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 
 	lb := ingress.NewLB()
-	client := k8s.NewClient()
-	controller := ingress.NewController(lb, client)
+	client := createK8sClient()
+
+	controller := ingress.New(lb, client)
 
 	go func() {
 		for sig := range c {
-			log.Infof("Signalled {}, shutting down.", sig)
+			log.Infof("Signalled %v, shutting down.", sig)
 			controller.Stop()
 		}
 	}()
 
 	controller.Run()
+}
+
+func configureLogging() {
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
+}
+
+func createK8sClient() k8s.Client {
+	caCert := readFile(caCertFile)
+	token := string(readFile(tokenFile))
+
+	client, err := k8s.New(apiServer, caCert, token)
+	if err != nil {
+		log.Errorf("Unable to create Kubernetes client: %v", err)
+		os.Exit(-1)
+	}
+
+	return client
+}
+
+func readFile(path string) []byte {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Errorf("Unable to read %s: %v", caCertFile, err)
+		os.Exit(-1)
+	}
+	return data
 }

--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -40,8 +40,6 @@ func (c *controller) Run() {
 	if err != nil {
 		log.Fatalf("Unable to watch ingresses: %v", err)
 		c.Stop()
-	} else {
-		go c.watchForUpdates(watcher)
 	}
 
 	// initialize with current state of ingress
@@ -50,6 +48,9 @@ func (c *controller) Run() {
 		log.Fatalf("Unable to update load balancer: %v", err)
 		c.Stop()
 	}
+
+	// consume updates after the initial select to avoid stale updates
+	go c.watchForUpdates(watcher)
 
 	<-c.stop
 	log.Infof("Controller has stopped")

--- a/ingress/controller_test.go
+++ b/ingress/controller_test.go
@@ -50,7 +50,7 @@ func TestControllerCanBeStopped(t *testing.T) {
 	// given
 	lb := new(fakeLb)
 	client := new(fakeClient)
-	controller := NewController(lb, client)
+	controller := New(lb, client)
 	client.On("GetIngresses").Return([]k8s.Ingress{}, nil)
 	client.On("WatchIngresses", mock.Anything).Return(nil)
 	lb.On("Update", mock.Anything).Return(nil)
@@ -65,7 +65,7 @@ func TestLoadBalancerUpdatesWithInitialIngress(t *testing.T) {
 	lb := new(fakeLb)
 	client := new(fakeClient)
 	ingresses := createIngressesFixture()
-	controller := NewController(lb, client)
+	controller := New(lb, client)
 
 	client.On("GetIngresses").Return(ingresses, nil)
 	client.On("WatchIngresses", mock.Anything).Return(nil)
@@ -89,7 +89,7 @@ func TestLoadBalancerUpdatesOnIngressUpdates(t *testing.T) {
 	lb := new(fakeLb)
 	client := new(fakeClient)
 	ingresses := createIngressesFixture()
-	controller := NewController(lb, client)
+	controller := New(lb, client)
 	watcherChan := make(chan k8s.Watcher, 1)
 
 	client.On("GetIngresses").Return([]k8s.Ingress{}, nil).Once()
@@ -158,13 +158,6 @@ func sendUpdate(watcher k8s.Watcher, value interface{}, d time.Duration) error {
 	return nil
 }
 
-const (
-	ingressHost    = "foo.sky.com"
-	ingressPath    = "/foo"
-	ingressSvcName = "foo-svc"
-	ingressSvcPort = 80
-)
-
 func createLbEntriesFixture() []LoadBalancerEntry {
 	return []LoadBalancerEntry{LoadBalancerEntry{
 		Host:        ingressHost,
@@ -173,6 +166,13 @@ func createLbEntriesFixture() []LoadBalancerEntry {
 		ServicePort: ingressSvcPort,
 	}}
 }
+
+const (
+	ingressHost    = "foo.sky.com"
+	ingressPath    = "/foo"
+	ingressSvcName = "foo-svc"
+	ingressSvcPort = 80
+)
 
 func createIngressesFixture() []k8s.Ingress {
 	paths := []k8s.HTTPIngressPath{k8s.HTTPIngressPath{

--- a/ingress/loadbalancer.go
+++ b/ingress/loadbalancer.go
@@ -21,11 +21,15 @@ type noopLoadBalancer struct {
 }
 
 func (lb *noopLoadBalancer) Update(entries []LoadBalancerEntry) error {
-	log.Infof("Updating loadbalancer {}", entries)
+	log.Debugf("Updating loadbalancer for %v", entries)
 	return nil
 }
 
 // NewLB creates a new LoadBalancer
 func NewLB() LoadBalancer {
 	return &noopLoadBalancer{}
+}
+
+func (lb *noopLoadBalancer) String() string {
+	return "[fake lb]"
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -25,7 +25,7 @@ type Client interface {
 	WatchIngresses(Watcher) error
 }
 
-type impl struct {
+type client struct {
 	baseURL string
 	caCert  []byte
 	token   string
@@ -53,7 +53,7 @@ func New(apiServerURL string, caCert []byte, token string) (Client, error) {
 	log.Debugf("Constructing client with url: %s, token: %s, caCert: %v",
 		baseURL, token, string(caCert))
 
-	return &impl{
+	return &client{
 			baseURL: baseURL,
 			caCert:  caCert,
 			token:   token,
@@ -61,14 +61,14 @@ func New(apiServerURL string, caCert []byte, token string) (Client, error) {
 		nil
 }
 
-func (i *impl) GetIngresses() ([]Ingress, error) {
-	endpoint := i.baseURL + "/apis/extensions/v1beta1/ingresses"
+func (c *client) GetIngresses() ([]Ingress, error) {
+	endpoint := c.baseURL + "/apis/extensions/v1beta1/ingresses"
 	req, err := http.NewRequest("GET", endpoint, nil)
-	req.Header.Add("Authorization", "Bearer "+i.token)
+	req.Header.Add("Authorization", "Bearer "+ c.token)
 
 	log.Debugf("k8s<-: %v", *req)
 
-	resp, err := i.client.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -96,11 +96,11 @@ func (i *impl) GetIngresses() ([]Ingress, error) {
 	return ingressList.Items, nil
 }
 
-func (i *impl) WatchIngresses(w Watcher) error {
+func (c *client) WatchIngresses(w Watcher) error {
 	log.Info("Watching ingresses")
 	return nil
 }
 
-func (i *impl) String() string {
-	return fmt.Sprintf("[k8s @ %s]", i.baseURL)
+func (c *client) String() string {
+	return fmt.Sprintf("[k8s @ %s]", c.baseURL)
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -25,7 +25,7 @@ type Client interface {
 	WatchIngresses(Watcher) error
 }
 
-type client struct {
+type clientImpl struct {
 	baseURL string
 	caCert  []byte
 	token   string
@@ -53,7 +53,7 @@ func New(apiServerURL string, caCert []byte, token string) (Client, error) {
 	log.Debugf("Constructing client with url: %s, token: %s, caCert: %v",
 		baseURL, token, string(caCert))
 
-	return &client{
+	return &clientImpl{
 			baseURL: baseURL,
 			caCert:  caCert,
 			token:   token,
@@ -61,13 +61,13 @@ func New(apiServerURL string, caCert []byte, token string) (Client, error) {
 		nil
 }
 
-func (c *client) GetIngresses() ([]Ingress, error) {
+func (c *clientImpl) GetIngresses() ([]Ingress, error) {
 	endpoint := c.baseURL + "/apis/extensions/v1beta1/ingresses"
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Authorization", "Bearer "+ c.token)
+	req.Header.Add("Authorization", "Bearer "+c.token)
 
 	log.Debugf("k8s<-: %v", *req)
 
@@ -99,11 +99,11 @@ func (c *client) GetIngresses() ([]Ingress, error) {
 	return ingressList.Items, nil
 }
 
-func (c *client) WatchIngresses(w Watcher) error {
+func (c *clientImpl) WatchIngresses(w Watcher) error {
 	log.Info("Watching ingresses")
 	return nil
 }
 
-func (c *client) String() string {
+func (c *clientImpl) String() string {
 	return fmt.Sprintf("[k8s @ %s]", c.baseURL)
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -7,6 +7,15 @@ The types are copied from the stable api of the Kubernetes 1.3 release.
 package k8s
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -16,27 +25,79 @@ type Client interface {
 	WatchIngresses(Watcher) error
 }
 
-type noopClient struct {
+type impl struct {
+	baseURL string
+	caCert  []byte
+	token   string
+	client  *http.Client
 }
 
-// NewClient creates a new K8 Client
-func NewClient() Client {
-	return &noopClient{}
+// New creates a client for the kubernetes apiserver.
+func New(apiServerURL string, caCert []byte, token string) (Client, error) {
+	parsedURL, err := url.Parse(apiServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid url %s: %v", apiServerURL, err)
+	}
+	baseURL := strings.TrimSuffix(parsedURL.String(), "/")
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caCert)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool},
+	}
+	client := &http.Client{Transport: tr}
+
+	log.Debugf("Constructing client with url: %s, token: %s, caCert: %v",
+		baseURL, token, string(caCert))
+
+	return &impl{
+			baseURL: baseURL,
+			caCert:  caCert,
+			token:   token,
+			client:  client},
+		nil
 }
 
-func (client *noopClient) GetIngresses() ([]Ingress, error) {
-	return []Ingress{}, nil
+func (i *impl) GetIngresses() ([]Ingress, error) {
+	endpoint := i.baseURL + "/apis/extensions/v1beta1/ingresses"
+	req, err := http.NewRequest("GET", endpoint, nil)
+	req.Header.Add("Authorization", "Bearer "+i.token)
+
+	log.Debugf("k8s<-: %v", *req)
+
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || 300 <= resp.StatusCode {
+		return nil, fmt.Errorf("GET %s returned %v", endpoint, resp)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("<-k8s:  %v", string(body))
+
+	var ingressList IngressList
+	err = json.Unmarshal(body, &ingressList)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("marshalled to %v", ingressList)
+
+	return ingressList.Items, nil
 }
 
-func (client *noopClient) WatchIngresses(w Watcher) error {
-	log.Infof("Watching ingresses {}", w)
-
-	go func() {
-		for i := 0; i < 10; i++ {
-			log.Infof("Sending fake update")
-			w.Updates() <- Ingress{}
-		}
-	}()
-
+func (i *impl) WatchIngresses(w Watcher) error {
+	log.Info("Watching ingresses")
 	return nil
+}
+
+func (i *impl) String() string {
+	return fmt.Sprintf("[k8s @ %s]", i.baseURL)
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -41,7 +41,10 @@ func New(apiServerURL string, caCert []byte, token string) (Client, error) {
 	baseURL := strings.TrimSuffix(parsedURL.String(), "/")
 
 	pool := x509.NewCertPool()
-	pool.AppendCertsFromPEM(caCert)
+	if ok := pool.AppendCertsFromPEM(caCert); !ok {
+		return nil, fmt.Errorf("unable to parse ca certificate")
+	}
+
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{RootCAs: pool},
 	}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -64,6 +64,9 @@ func New(apiServerURL string, caCert []byte, token string) (Client, error) {
 func (c *client) GetIngresses() ([]Ingress, error) {
 	endpoint := c.baseURL + "/apis/extensions/v1beta1/ingresses"
 	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Add("Authorization", "Bearer "+ c.token)
 
 	log.Debugf("k8s<-: %v", *req)

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -1,0 +1,144 @@
+package k8s
+
+import (
+	"testing"
+
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidUrlReturnsError(t *testing.T) {
+	_, err := New("%gh&%ij", []byte{}, "")
+	assert.Error(t, err)
+}
+
+func TestRetrievesIngressesFromKubernetes(t *testing.T) {
+	assert := assert.New(t)
+
+	ingressFixture := CreateIngressesFixture()
+	ts := httptest.NewTLSServer(handleGetIngresses(t, authToken, ingressFixture))
+	defer ts.Close()
+
+	client, err := New(ts.URL, caCert, authToken)
+	assert.NoError(err)
+
+	ingresses, err := client.GetIngresses()
+	assert.NoError(err)
+
+	assertEqualIngresses(t, ingressFixture, ingresses)
+}
+
+func TestErrorIfNon200StatusCode(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewTLSServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	client, err := New(ts.URL, caCert, authToken)
+	assert.NoError(err)
+
+	_, err = client.GetIngresses()
+	assert.Error(err)
+}
+
+func TestErrorIfInvalidJson(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("{__Asdfkez--garbagel"))
+		assert.NoError(err)
+	}))
+	defer ts.Close()
+
+	client, err := New(ts.URL, caCert, authToken)
+	assert.NoError(err)
+
+	_, err = client.GetIngresses()
+	assert.Error(err)
+}
+
+func assertEqualIngresses(t *testing.T, expected []Ingress, actual []Ingress) {
+	assert := assert.New(t)
+	assert.Equal(len(expected), len(actual))
+	for i, expected := range expected {
+		actual := actual[i]
+		assert.Equal(expected.Name, actual.Name)
+		assert.Equal(len(expected.Spec.Rules), len(actual.Spec.Rules))
+		for j := range expected.Spec.Rules {
+			assert.Equal(expected.Spec.Rules[j], actual.Spec.Rules[j])
+		}
+	}
+}
+
+func handleGetIngresses(t *testing.T, token string, ingresses []Ingress) http.Handler {
+	assert := assert.New(t)
+	ingressList := &IngressList{Items: ingresses}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/apis/extensions/v1beta1/ingresses", r.URL.Path)
+		assertAuthToken(t, r)
+		bytes, err := json.Marshal(ingressList)
+		assert.NoError(err)
+		_, err = w.Write(bytes)
+		assert.NoError(err)
+	})
+}
+
+func assertAuthToken(t *testing.T, r *http.Request) {
+	auths := r.Header["Authorization"]
+	if len(auths) != 1 {
+		assert.Fail(t, "Expected one authorization header, but got none")
+	} else {
+		assert.Equal(t, "Bearer "+authToken, r.Header["Authorization"][0],
+			"Should authenticate with correct token to apiserver")
+	}
+}
+
+const (
+	ingressHost    = "foo.sky.com"
+	ingressPath    = "/foo"
+	ingressSvcName = "foo-svc"
+	ingressSvcPort = 80
+	authToken      = "validtoken"
+)
+
+func CreateIngressesFixture() []Ingress {
+	paths := []HTTPIngressPath{HTTPIngressPath{
+		Path: ingressPath,
+		Backend: IngressBackend{
+			ServiceName: ingressSvcName,
+			ServicePort: FromInt(ingressSvcPort),
+		},
+	}}
+	return []Ingress{
+		Ingress{
+			ObjectMeta: ObjectMeta{Name: "foo-ingress"},
+			Spec: IngressSpec{
+				Rules: []IngressRule{IngressRule{
+					Host: ingressHost,
+					IngressRuleValue: IngressRuleValue{HTTP: &HTTPIngressRuleValue{
+						Paths: paths,
+					}},
+				}},
+			},
+		},
+	}
+}
+
+// From testcert.go, used by httptest for TLS
+var caCert = []byte(`-----BEGIN CERTIFICATE-----
+MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9SjY1bIw4
+iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZBl2+XsDul
+rKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQABo2gwZjAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAuBgNVHREEJzAlggtleGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAA
+AAAAATANBgkqhkiG9w0BAQsFAAOBgQCEcetwO59EWk7WiJsG4x8SY+UIAA+flUI9
+tyC4lNhbcF2Idq9greZwbYCqTTTr2XiRNSMLCOjKyI7ukPoPjo16ocHj+P3vZGfs
+h1fIw3cSS2OolhloGw/XM6RWPWtPAlGykKLciQrBru5NAPvCMsb/I1DAceTiotQM
+fblo6RBxUQ==
+-----END CERTIFICATE-----`)

--- a/k8s/types.go
+++ b/k8s/types.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -58,6 +60,28 @@ func (intstr *IntOrString) IntValue() int {
 		return i
 	}
 	return int(intstr.IntVal)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (intstr *IntOrString) UnmarshalJSON(value []byte) error {
+	if value[0] == '"' {
+		intstr.Type = String
+		return json.Unmarshal(value, &intstr.StrVal)
+	}
+	intstr.Type = Int
+	return json.Unmarshal(value, &intstr.IntVal)
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (intstr IntOrString) MarshalJSON() ([]byte, error) {
+	switch intstr.Type {
+	case Int:
+		return json.Marshal(intstr.IntVal)
+	case String:
+		return json.Marshal(intstr.StrVal)
+	default:
+		return []byte{}, fmt.Errorf("impossible IntOrString.Type")
+	}
 }
 
 // TypeMeta describes an individual object in an API response or request


### PR DESCRIPTION
This PR adds real retrieval of ingresses from the apiserver. It also wires it up into the `feed-ingress` binary.

Also adds some new flags:

```
$ feed-ingress -h                                                                                        (k8s-client) 
Usage of feed-ingress:
  -apiserver string
    	Kubernetes API server URL (default "https://10.254.0.1:443")
  -cacertfile string
    	file containing kubernetes ca certificate (default "/run/secrets/kubernetes.io/serviceaccount/ca.crt")
  -debug
    	enable debug logging
  -tokenfile string
    	file containing kubernetes client authentication token (default "/run/secrets/kubernetes.io/serviceaccount/token")
```

Debug was added for some low level messages I added to check things were working against a real apiserver.