### PR TITLE
Add health port to ingress controller

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -37,7 +37,7 @@ func init() {
 		defaultNginxConfDir = "."
 		defaultIngressPort  = 80
 		defaultNginxWorkers = 1
-		defaultHealthPort   = 12001
+		defaultHealthPort   = 12082
 	)
 
 	flag.StringVar(&apiServer, "apiserver", defaultAPIServer, "Kubernetes API server URL")
@@ -111,7 +111,7 @@ func configureHealthPort(controller ingress.Controller) {
 	http.HandleFunc("/health", checkHealth(controller))
 
 	go func() {
-		log.Error(http.ListenAndServe("localhost:"+strconv.Itoa(healthPort), nil))
+		log.Error(http.ListenAndServe(":"+strconv.Itoa(healthPort), nil))
 		log.Info(controller.Stop())
 		os.Exit(-1)
 	}()

--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -125,7 +125,13 @@ func (c *controller) updateLoadBalancer() error {
 
 	log.Infof("Updating load balancer with %d entry(s)", len(entries))
 	updated, err := c.lb.Update(LoadBalancerUpdate{entries})
-	log.Infof("Load balancer updated? %s", updated)
+	if err == nil {
+		if updated {
+			log.Info("Load balancer updated")
+		} else {
+			log.Info("No changes")
+		}
+	}
 	return err
 }
 

--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -5,20 +5,31 @@ and updates the ingress load balancer. It also runs the load balancer.
 package ingress
 
 import (
+	"sync"
+
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/sky-uk/feed/k8s"
 )
 
 // Controller for Kubernetes ingress.
 type Controller interface {
-	Run()
-	Stop()
+	// Run the controller, blocking until it stops. Returns an error if it failed to start.
+	Start() error
+	// Stop the controller, blocking until it stops. Returns an error if unable to stop.
+	Stop() error
+	// Healthy returns true for a healthy controller, false for unhealthy.
+	Healthy() bool
 }
 
 type controller struct {
-	lb     LoadBalancer
-	client k8s.Client
-	stop   chan struct{}
+	lb            LoadBalancer
+	client        k8s.Client
+	stopCh        chan struct{}
+	doneCh        chan struct{}
+	started       safeBool
+	startStopLock sync.Mutex
 }
 
 // New creates an ingress controller.
@@ -26,31 +37,58 @@ func New(loadBalancer LoadBalancer, kubernetesClient k8s.Client) Controller {
 	return &controller{
 		lb:     loadBalancer,
 		client: kubernetesClient,
-		stop:   make(chan struct{}),
 	}
 }
 
-func (c *controller) Run() {
-	log.Infof("Starting controller for %v and %v", c.lb, c.client)
-
+func (c *controller) Start() error {
 	watcher := k8s.NewWatcher()
 	defer close(watcher.Done())
 
-	err := c.client.WatchIngresses(watcher)
+	err := c.startIt(watcher)
 	if err != nil {
-		log.Fatalf("Unable to watch ingresses: %v", err)
-		c.Stop()
+		return err
 	}
+
+	<-c.stopCh
+	close(c.doneCh)
+	return nil
+}
+
+func (c *controller) startIt(watcher k8s.Watcher) error {
+	c.startStopLock.Lock()
+	defer c.startStopLock.Unlock()
+
+	if c.started.get() {
+		return fmt.Errorf("controller is already started")
+	}
+
+	if c.stopCh != nil || c.doneCh != nil {
+		return fmt.Errorf("can't restart controller")
+	}
+
+	err := c.lb.Start()
+	if err != nil {
+		return fmt.Errorf("unable to start load balancer: %v", err)
+	}
+
+	err = c.client.WatchIngresses(watcher)
+	if err != nil {
+		return fmt.Errorf("unable to watch ingresses: %v", err)
+	}
+
+	c.stopCh = make(chan struct{})
+	c.doneCh = make(chan struct{})
+
 	go c.watchForUpdates(watcher)
 
-	<-c.stop
-	log.Infof("Controller has stopped")
+	c.started.set(true)
+	return nil
 }
 
 func (c *controller) watchForUpdates(watcher k8s.Watcher) {
 	for {
 		select {
-		case <-c.stop:
+		case <-c.stopCh:
 			return
 		case <-watcher.Updates():
 			log.Info("Received update on watcher")
@@ -91,8 +129,55 @@ func (c *controller) updateLoadBalancer() error {
 	return err
 }
 
-func (c *controller) Stop() {
+func (c *controller) Stop() error {
+	err := c.stopIt()
+	if err != nil {
+		return err
+	}
+
+	<-c.doneCh
+	log.Infof("Controller has stopped")
+	return nil
+}
+
+func (c *controller) stopIt() error {
+	c.startStopLock.Lock()
+	defer c.startStopLock.Unlock()
+
+	if !c.started.get() {
+		return fmt.Errorf("cannot stop, not started")
+	}
+
 	log.Info("Stopping controller")
-	c.lb.Stop()
-	close(c.stop)
+
+	err := c.lb.Stop()
+	if err != nil {
+		log.Warn("Error while stopping load balancer: ", err)
+	}
+
+	close(c.stopCh)
+	c.started.set(false)
+
+	return nil
+}
+
+func (c *controller) Healthy() bool {
+	return c.started.get()
+}
+
+type safeBool struct {
+	lock sync.Mutex
+	val  bool
+}
+
+func (b *safeBool) get() bool {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.val
+}
+
+func (b *safeBool) set(newVal bool) {
+	b.lock.Lock()
+	b.val = newVal
+	b.lock.Unlock()
 }

--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -125,14 +125,17 @@ func (c *controller) updateLoadBalancer() error {
 
 	log.Infof("Updating load balancer with %d entry(s)", len(entries))
 	updated, err := c.lb.Update(LoadBalancerUpdate{entries})
-	if err == nil {
-		if updated {
-			log.Info("Load balancer updated")
-		} else {
-			log.Info("No changes")
-		}
+	if err != nil {
+		return err
 	}
-	return err
+
+	if updated {
+		log.Info("Load balancer updated")
+	} else {
+		log.Info("No changes")
+	}
+
+	return nil
 }
 
 func (c *controller) Stop() error {

--- a/ingress/loadbalancer_test.go
+++ b/ingress/loadbalancer_test.go
@@ -32,12 +32,14 @@ func (m *mockSignaller) Sighup(p *os.Process) error {
 }
 
 func newLb(tmpDir string, mockSignaller Signaller) LoadBalancer {
-	return NewNginxLB(&NginxConf{
+	lb := NewNginxLB(NginxConf{
 		BinaryLocation:  "./fake_nginx.sh",
 		ConfigDir:       tmpDir,
 		Port:            port,
 		WorkerProcesses: 1,
-	}, mockSignaller)
+	})
+	lb.(*nginxLoadBalancer).signaller = mockSignaller
+	return lb
 }
 
 func TestGracefulShutdown(t *testing.T) {

--- a/ingress/nginx.go
+++ b/ingress/nginx.go
@@ -22,14 +22,14 @@ type NginxConf struct {
 
 // Nginx implementation
 type nginxLoadBalancer struct {
-	conf      *NginxConf
+	conf      NginxConf
 	cmd       *exec.Cmd
 	signaller Signaller
 }
 
 // Used for generating nginx cofnig
 type loadBalancerTemplate struct {
-	Config  *NginxConf
+	Config  NginxConf
 	Entries []LoadBalancerEntry
 }
 
@@ -38,10 +38,10 @@ func (lb *nginxLoadBalancer) configLocation() string {
 }
 
 // NewNginxLB creates a new LoadBalancer
-func NewNginxLB(nginxConf *NginxConf, signaller Signaller) LoadBalancer {
+func NewNginxLB(nginxConf NginxConf) LoadBalancer {
 	return &nginxLoadBalancer{
 		conf:      nginxConf,
-		signaller: signaller}
+		signaller: &DefaultSignaller{}}
 }
 
 func (lb *nginxLoadBalancer) Start() error {

--- a/ingress/nginx.go
+++ b/ingress/nginx.go
@@ -57,7 +57,7 @@ func (lb *nginxLoadBalancer) Start() error {
 	lb.cmd = cmd
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("Inable to start nginx %v", err)
+		return fmt.Errorf("Unable to start nginx %v", err)
 	}
 
 	go func() {
@@ -69,7 +69,7 @@ func (lb *nginxLoadBalancer) Start() error {
 }
 
 func (lb *nginxLoadBalancer) Stop() error {
-	log.Info("Shutting down process %d", lb.cmd.Process.Pid)
+	log.Infof("Shutting down process %d", lb.cmd.Process.Pid)
 	err := lb.signaller.Sigquit(lb.cmd.Process)
 	if err != nil {
 		return fmt.Errorf("Error shutting down nginx %v", err)

--- a/ingress/nginx.go
+++ b/ingress/nginx.go
@@ -57,7 +57,7 @@ func (lb *nginxLoadBalancer) Start() error {
 	lb.cmd = cmd
 	err := cmd.Start()
 	if err != nil {
-		return fmt.Errorf("Unable to start nginx %v", err)
+		return fmt.Errorf("unable to start nginx: %v", err)
 	}
 
 	go func() {
@@ -72,7 +72,7 @@ func (lb *nginxLoadBalancer) Stop() error {
 	log.Infof("Shutting down process %d", lb.cmd.Process.Pid)
 	err := lb.signaller.Sigquit(lb.cmd.Process)
 	if err != nil {
-		return fmt.Errorf("Error shutting down nginx %v", err)
+		return fmt.Errorf("error shutting down nginx: %v", err)
 	}
 	return nil
 }
@@ -80,12 +80,12 @@ func (lb *nginxLoadBalancer) Stop() error {
 func (lb *nginxLoadBalancer) Update(entries LoadBalancerUpdate) (bool, error) {
 	updated, err := lb.update(entries)
 	if err != nil {
-		return false, fmt.Errorf("Unable to update nginx %v", err)
+		return false, fmt.Errorf("unable to update nginx: %v", err)
 	}
 	if updated {
 		err = lb.signaller.Sighup(lb.cmd.Process)
 		if err != nil {
-			return false, fmt.Errorf("Configuration was wirtten but unable to signal nginx to reload configuration %v", err)
+			return false, fmt.Errorf("unable to signal nginx to reload: %v", err)
 		}
 	}
 	return updated, err


### PR DESCRIPTION
Adds /health and /debug/pprof.

Also:
- Properly os.Exit(-1) if the controller has an error
- Controller controls load balancer lifecycle start
- Make controller start/stop safe, and validate controller state
