### PR TITLE
Use nginx user and move release into Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,4 @@ services:
   - docker
 
 after_success:
-  - docker login -e $DOCKER_EMAIL -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - export REPO=skycirrus/feed-ingress
-  - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
-  - cd docker && docker build -f Dockerfile -t $REPO:$COMMIT .
-  - docker tag $REPO:$COMMIT $REPO:$TAG
-  - docker push $REPO
-
-env:
-  global:
-    - COMMIT=${TRAVIS_COMMIT::8}
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then make release; fi

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ docker : copy
 
 release : docker
 	@echo "== releasing docker image"
-	docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
+	docker login -e $(DOCKER_EMAIL) -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
 	docker tag $(docker_tag) $(docker_latest)
 	docker push $(docker_tag)
 	docker push $(docker_latest)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ pkgs = $(shell go list ./... | grep -v /vendor/)
 files = $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 ingress_binary = $(GOPATH)/bin/feed-ingress
 template = ./ingress/nginx.tmpl
+docker_repo = skycirrus/feed-ingress
+git_rev = $(shell git rev-parse --short HEAD)
+docker_tag = "$(docker_repo):$(git_rev)"
+docker_latest = "$(docker_repo):latest"
 
 all : format vet lint test build copy
 
@@ -27,9 +31,21 @@ lint :
 		golint -set_exit_status $$pkg || exit 1; \
 	done;
 
-copy :
-	@echo "== coping files to docker"
+copy : build
+	@echo "== copying binaries to docker/"
 	cp $(ingress_binary) ./docker/
 	cp $(template) ./docker/
 
-.PHONY: all format test build vet lint copy
+docker : copy
+	@echo "== building docker image"
+	docker build -t $(docker_tag) docker/.
+	@echo "Built $(docker_tag)"
+
+release : docker
+	@echo "== releasing docker image"
+	docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
+	docker tag $(docker_tag) $(docker_latest)
+	docker push $(docker_tag)
+	docker push $(docker_latest)
+
+.PHONY: all format test build vet lint copy docker release

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -34,7 +34,7 @@ func init() {
 		defaultAPIServer       = "https://kubernetes:443"
 		defaultCaCertFile      = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 		defaultTokenFile       = "/run/secrets/kubernetes.io/serviceaccount/token"
-		defaultNginxWorkingDir = "/"
+		defaultNginxWorkingDir = "/nginx"
 		defaultIngressPort     = 80
 		defaultNginxWorkers    = 1
 		defaultHealthPort      = 12082

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,11 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC64107
 						gettext-base \
 	&& rm -rf /var/lib/apt/lists/*
 
+WORKDIR /
 COPY feed-ingress /
-COPY nginx.tmpl /
+RUN mkdir /nginx
+COPY nginx.tmpl /nginx/
 
-ENTRYPOINT ["/feed-ingress"]
+USER nginx
+
+ENTRYPOINT ["/feed-ingress", "-nginx-workdir", "/nginx"]


### PR DESCRIPTION
Also change it to only release on master builds. To limit number of
images we have (I don't think we need branch builds? We can always push
it locally if we really need it).

And change default ingress port to 8080 so we don't need super user rights
to start up nginx. Needed so we can run as nginx in the Dockerfile.