### PR TITLE
Print nginx version on startup

### DIFF
--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -40,14 +40,6 @@ func New(loadBalancer LoadBalancer, kubernetesClient k8s.Client) Controller {
 }
 
 func (c *controller) Start() error {
-	if err := c.startIt(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *controller) startIt() error {
 	c.startStopLock.Lock()
 	defer c.startStopLock.Unlock()
 
@@ -130,16 +122,6 @@ func (c *controller) updateLoadBalancer() error {
 }
 
 func (c *controller) Stop() error {
-	err := c.stopIt()
-	if err != nil {
-		return err
-	}
-
-	log.Info("Controller has stopped")
-	return nil
-}
-
-func (c *controller) stopIt() error {
 	c.startStopLock.Lock()
 	defer c.startStopLock.Unlock()
 
@@ -156,6 +138,7 @@ func (c *controller) stopIt() error {
 	}
 
 	c.started = false
+	log.Info("Controller has stopped")
 	return nil
 }
 

--- a/ingress/fake_graceful_nginx.py
+++ b/ingress/fake_graceful_nginx.py
@@ -10,6 +10,11 @@ def signal_handler(signal, frame):
     sys.exit(0)
 
 print('Running {}'.format(str(sys.argv)))
+
+if sys.argv[1] == '-v':
+    print('Asked for version')
+    sys.exit(0)
+
 # The parent golang process blocks SIGQUIT in subprocesses, for some reason.
 # So we unblock it manually - same as what nginx does.
 signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGQUIT})

--- a/ingress/nginx.go
+++ b/ingress/nginx.go
@@ -79,6 +79,10 @@ func NewNginxLB(nginxConf NginxConf) LoadBalancer {
 }
 
 func (lb *nginxLoadBalancer) Start() error {
+	if err := lb.logNginxVersion(); err != nil {
+		return err
+	}
+
 	if err := lb.initialiseNginxConf(); err != nil {
 		return fmt.Errorf("unable to initialise nginx config: %v", err)
 	}
@@ -104,6 +108,13 @@ func (lb *nginxLoadBalancer) Start() error {
 
 	log.Debugf("Nginx pid %d", lb.cmd.Process.Pid)
 	return nil
+}
+
+func (lb *nginxLoadBalancer) logNginxVersion() error {
+	cmd := exec.Command(lb.BinaryLocation, "-v")
+	cmd.Stdout = log.StandardLogger().Writer()
+	cmd.Stderr = log.StandardLogger().Writer()
+	return cmd.Run()
 }
 
 func (lb *nginxLoadBalancer) initialiseNginxConf() error {


### PR DESCRIPTION
So we know what version is running in our clusters (for security
updates, and things).