### PR TITLE
Fix unkeyed literals

### DIFF
--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -108,7 +108,7 @@ func (c *controller) updateLoadBalancer() error {
 	}
 
 	log.Infof("Updating load balancer with %d entry(s)", len(entries))
-	updated, err := c.lb.Update(api.LoadBalancerUpdate{entries})
+	updated, err := c.lb.Update(api.LoadBalancerUpdate{Entries: entries})
 	if err != nil {
 		return err
 	}

--- a/ingress/controller_test.go
+++ b/ingress/controller_test.go
@@ -238,7 +238,7 @@ func sendUpdate(watcher k8s.Watcher, value interface{}, d time.Duration) error {
 }
 
 func createLbEntriesFixture() api.LoadBalancerUpdate {
-	return api.LoadBalancerUpdate{[]api.LoadBalancerEntry{api.LoadBalancerEntry{
+	return api.LoadBalancerUpdate{Entries: []api.LoadBalancerEntry{api.LoadBalancerEntry{
 		Host:        ingressHost,
 		Path:        ingressPath,
 		ServiceName: ingressSvcName,

--- a/ingress/nginx/nginx_test.go
+++ b/ingress/nginx/nginx_test.go
@@ -114,7 +114,7 @@ func TestReloadOfConfig(t *testing.T) {
 			ServicePort: 9090,
 		},
 	}
-	updated, err := lb.Update(api.LoadBalancerUpdate{entries})
+	updated, err := lb.Update(api.LoadBalancerUpdate{Entries: entries})
 	assert.NoError(t, err)
 	assert.True(t, updated)
 
@@ -149,11 +149,11 @@ func TestDoesNotUpdateIfConfigurationHasNotChanged(t *testing.T) {
 			ServicePort: 9090,
 		},
 	}
-	updated, err := lb.Update(api.LoadBalancerUpdate{entries})
+	updated, err := lb.Update(api.LoadBalancerUpdate{Entries: entries})
 	assert.NoError(t, err)
 	assert.True(t, updated)
 
-	updated, err = lb.Update(api.LoadBalancerUpdate{entries})
+	updated, err = lb.Update(api.LoadBalancerUpdate{Entries: entries})
 	assert.NoError(t, err)
 	assert.False(t, updated)
 }
@@ -173,7 +173,7 @@ func TestInvalidLoadBalancerEntryIsIgnored(t *testing.T) {
 			ServicePort: 9090,
 		},
 	}
-	updated, err := lb.Update(api.LoadBalancerUpdate{entries})
+	updated, err := lb.Update(api.LoadBalancerUpdate{Entries: entries})
 	assert.NoError(t, err)
 
 	// Add an invalid entry
@@ -191,7 +191,7 @@ func TestInvalidLoadBalancerEntryIsIgnored(t *testing.T) {
 			ServicePort: 9090,
 		},
 	}
-	updated, err = lb.Update(api.LoadBalancerUpdate{entries})
+	updated, err = lb.Update(api.LoadBalancerUpdate{Entries: entries})
 	assert.NoError(t, err)
 	assert.False(t, updated)
 }


### PR DESCRIPTION
Make `go vet` happy.