### PR TITLE
Include ingress namespace on service backend

### DIFF
--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -95,10 +95,11 @@ func (c *controller) updateLoadBalancer() error {
 	for _, ingress := range ingresses {
 		for _, rule := range ingress.Spec.Rules {
 			for _, path := range rule.HTTP.Paths {
+				serviceName := fmt.Sprintf("%s.%s", path.Backend.ServiceName, ingress.Namespace)
 				entry := api.LoadBalancerEntry{
 					Host:        rule.Host,
 					Path:        path.Path,
-					ServiceName: path.Backend.ServiceName,
+					ServiceName: serviceName,
 					ServicePort: int32(path.Backend.ServicePort.IntValue()),
 				}
 

--- a/ingress/controller_test.go
+++ b/ingress/controller_test.go
@@ -241,16 +241,17 @@ func createLbEntriesFixture() api.LoadBalancerUpdate {
 	return api.LoadBalancerUpdate{Entries: []api.LoadBalancerEntry{api.LoadBalancerEntry{
 		Host:        ingressHost,
 		Path:        ingressPath,
-		ServiceName: ingressSvcName,
+		ServiceName: ingressSvcName + "." + ingressNamespace,
 		ServicePort: ingressSvcPort,
 	}}}
 }
 
 const (
-	ingressHost    = "foo.sky.com"
-	ingressPath    = "/foo"
-	ingressSvcName = "foo-svc"
-	ingressSvcPort = 80
+	ingressHost      = "foo.sky.com"
+	ingressPath      = "/foo"
+	ingressSvcName   = "foo-svc"
+	ingressSvcPort   = 80
+	ingressNamespace = "happysky"
 )
 
 func createIngressesFixture() []k8s.Ingress {
@@ -263,7 +264,7 @@ func createIngressesFixture() []k8s.Ingress {
 	}}
 	return []k8s.Ingress{
 		k8s.Ingress{
-			ObjectMeta: k8s.ObjectMeta{Name: "foo-ingress"},
+			ObjectMeta: k8s.ObjectMeta{Name: "foo-ingress", Namespace: ingressNamespace},
 			Spec: k8s.IngressSpec{
 				Rules: []k8s.IngressRule{k8s.IngressRule{
 					Host: ingressHost,


### PR DESCRIPTION
The ingress resource is namespaced to the service. Since nginx runs in
kube-system, we need the namespace appended to the service name so it can
resolve the service ip.
