### PR TITLE
Change `vet` to depend on `build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifneq "$(unformatted)" ""
 	@exit 1
 endif
 
-vet :
+vet : build
 	@echo "== vet"
 	@go vet $(pkgs)
 


### PR DESCRIPTION
This is necessary since some of the vet checks require that the packages
are installed first.