### PR TITLE
Add ability to specify dns resolver

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -23,14 +23,15 @@ import (
 )
 
 var (
-	nginxConfDir         string
 	ingressPort          int
-	nginxWorkerProcesses int
 	apiServer            string
 	caCertFile           string
 	tokenFile            string
 	debug                bool
 	healthPort           int
+	nginxWorkDir         string
+	nginxWorkerProcesses int
+	nginxResolver        string
 )
 
 func init() {
@@ -47,11 +48,12 @@ func init() {
 	flag.StringVar(&apiServer, "apiserver", defaultAPIServer, "Kubernetes API server URL.")
 	flag.StringVar(&caCertFile, "cacertfile", defaultCaCertFile, "File containing kubernetes ca certificate.")
 	flag.StringVar(&tokenFile, "tokenfile", defaultTokenFile, "File containing kubernetes client authentication token.")
-	flag.StringVar(&nginxConfDir, "nginx-workdir", defaultNginxWorkingDir, "Directory to store nginx files. Also the location of the nginx.tmpl file.")
 	flag.IntVar(&ingressPort, "ingress-port", defaultIngressPort, "Port to server ingress traffic.")
-	flag.IntVar(&nginxWorkerProcesses, "nginx-workers", defaultNginxWorkers, "Number of nginx worker processes.")
 	flag.BoolVar(&debug, "debug", false, "Enable debug logging.")
 	flag.IntVar(&healthPort, "health-port", defaultHealthPort, "Port for checking the health of the ingress controller.")
+	flag.StringVar(&nginxWorkDir, "nginx-workdir", defaultNginxWorkingDir, "Directory to store nginx files. Also the location of the nginx.tmpl file.")
+	flag.IntVar(&nginxWorkerProcesses, "nginx-workers", defaultNginxWorkers, "Number of nginx worker processes.")
+	flag.StringVar(&nginxResolver, "nginx-resolver", "", "Address to resolve DNS entries for backends. Leave blank to use host DNS resolving.")
 }
 
 func main() {
@@ -85,9 +87,10 @@ func configureLogging() {
 func createLB() api.LoadBalancer {
 	return nginx.NewNginxLB(nginx.Conf{
 		BinaryLocation:  "/usr/sbin/nginx",
-		WorkingDir:      nginxConfDir,
+		WorkingDir:      nginxWorkDir,
 		WorkerProcesses: nginxWorkerProcesses,
 		Port:            ingressPort,
+		Resolver:        nginxResolver,
 	})
 }
 

--- a/ingress/nginx/nginx.go
+++ b/ingress/nginx/nginx.go
@@ -28,6 +28,7 @@ type Conf struct {
 	WorkingDir      string
 	WorkerProcesses int
 	Port            int
+	Resolver        string
 }
 
 // Signaller interface around signalling the loadbalancer process

--- a/ingress/nginx/nginx.tmpl
+++ b/ingress/nginx/nginx.tmpl
@@ -18,6 +18,10 @@ http {
     sendfile           on;
     keepalive_timeout  65;
 
+    # DNS resolving
+    resolver_timeout 5s;
+    {{ if .Config.Resolver }}resolver {{ .Config.Resolver }};{{ end }}
+
     # Put all data into the working directory
     access_log             {{ .Config.WorkingDir }}/access.log main gzip;
     client_body_temp_path  {{ .Config.WorkingDir }}/tmp_client_body 1 2;


### PR DESCRIPTION
This is necessary in Kubernetes so we can specify skydns, since the pod
will be running on host networking.