### PR TITLE
Restrict ingress access

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -30,6 +30,7 @@ var (
 	caCertFile             string
 	tokenFile              string
 	ingressPort            int
+	ingressAllow           string
 	healthPort             int
 	nginxBinary            string
 	nginxWorkDir           string
@@ -47,6 +48,7 @@ func init() {
 		defaultCaCertFile             = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 		defaultTokenFile              = "/run/secrets/kubernetes.io/serviceaccount/token"
 		defaultIngressPort            = 8080
+		defaultIngressAllow           = ""
 		defaultHealthPort             = 12082
 		defaultServiceDomain          = "svc.cluster"
 		defaultNginxBinary            = "/usr/sbin/nginx"
@@ -67,6 +69,9 @@ func init() {
 		"File containing kubernetes client authentication token.")
 	flag.IntVar(&ingressPort, "ingress-port", defaultIngressPort,
 		"Port to serve ingress traffic to backend services.")
+	flag.StringVar(&ingressAllow, "ingress-allow", defaultIngressAllow,
+		"Source IP or CIDR to allow ingress access by default. This is in addition to the sky.uk/allow "+
+			"annotation on ingress resources. Leave empty to deny all access by default.")
 	flag.IntVar(&healthPort, "health-port", defaultHealthPort,
 		"Port for checking the health of the ingress controller.")
 	flag.StringVar(&serviceDomain, "service-domain", defaultServiceDomain,
@@ -129,6 +134,7 @@ func createLB() api.LoadBalancer {
 		KeepAliveSeconds:  nginxKeepAliveSeconds,
 		StatusPort:        nginxStatusPort,
 		Resolver:          nginxResolver,
+		DefaultAllow:      ingressAllow,
 	})
 }
 

--- a/ingress/api/lb_entry.go
+++ b/ingress/api/lb_entry.go
@@ -11,10 +11,16 @@ type LoadBalancerUpdate struct {
 
 // LoadBalancerEntry describes the ingress for a single host, path, and service.
 type LoadBalancerEntry struct {
-	Host        string
-	Path        string
+	// Host is the fully qualified domain name used for external access.
+	Host string
+	// Path is the url path after the hostname.
+	Path string
+	// ServiceName is the Kubernetes backend service to proxy traffic to.
 	ServiceName string
+	// ServicePort is the port to proxy traffic to.
 	ServicePort int32
+	// SourceRange is the ip or cidr that is allowed to access the service.
+	Allow string
 }
 
 // FilterInvalidEntries returns a slice of all the valid LoadBalancer entries

--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sky-uk/feed/k8s"
 )
 
+const ingressAllowAnnotation = "sky.uk/allow"
+
 // Controller for Kubernetes ingress.
 type Controller interface {
 	// Run the controller, returning immediately after it starts or an error occurs.
@@ -111,6 +113,7 @@ func (c *controller) updateLoadBalancer() error {
 					Path:        path.Path,
 					ServiceName: serviceName,
 					ServicePort: int32(path.Backend.ServicePort.IntValue()),
+					Allow:       ingress.Annotations[ingressAllowAnnotation],
 				}
 
 				entries = append(entries, entry)

--- a/ingress/controller_test.go
+++ b/ingress/controller_test.go
@@ -179,7 +179,7 @@ func TestUnhealthyIfNotWatchingForUpdates(t *testing.T) {
 	assert := assert.New(t)
 	lb, _ := createDefaultStubs()
 	client := new(fakeClient)
-	controller := New(lb, client)
+	controller := newController(lb, client)
 
 	watcherChan := make(chan k8s.Watcher, 1)
 	client.On("WatchIngresses", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -262,6 +262,7 @@ func createLbEntriesFixture() api.LoadBalancerUpdate {
 		Path:        ingressPath,
 		ServiceName: ingressSvcName + "." + ingressNamespace + "." + serviceDomain,
 		ServicePort: ingressSvcPort,
+		Allow:       ingressAllow,
 	}}}
 }
 
@@ -272,6 +273,7 @@ const (
 	ingressSvcPort   = 80
 	ingressNamespace = "happysky"
 	serviceDomain    = "svc.skycluster"
+	ingressAllow     = "10.82.0.0/16"
 )
 
 func createIngressesFixture() []k8s.Ingress {
@@ -284,7 +286,11 @@ func createIngressesFixture() []k8s.Ingress {
 	}}
 	return []k8s.Ingress{
 		k8s.Ingress{
-			ObjectMeta: k8s.ObjectMeta{Name: "foo-ingress", Namespace: ingressNamespace},
+			ObjectMeta: k8s.ObjectMeta{
+				Name:        "foo-ingress",
+				Namespace:   ingressNamespace,
+				Annotations: map[string]string{ingressAllowAnnotation: ingressAllow},
+			},
 			Spec: k8s.IngressSpec{
 				Rules: []k8s.IngressRule{k8s.IngressRule{
 					Host: ingressHost,

--- a/ingress/nginx/nginx.go
+++ b/ingress/nginx/nginx.go
@@ -32,6 +32,7 @@ type Conf struct {
 	StatusPort        int
 	IngressPort       int
 	Resolver          string
+	DefaultAllow      string
 }
 
 // Signaller interface around signalling the loadbalancer process

--- a/ingress/nginx/nginx.tmpl
+++ b/ingress/nginx/nginx.tmpl
@@ -29,13 +29,18 @@ http {
     # Keep alive time for client connections
     keepalive_timeout {{ .Config.KeepAliveSeconds }}s;
 
-    # Optimize for latency over throughput for persistent connections.
+    # Optimize for latency over throughput for persistent connections
     tcp_nodelay on;
 
     # DNS resolving
     # Fail faster if dns is unresponsive. Default is 30s.
     resolver_timeout 5s;
     {{ if .Config.Resolver }}resolver {{ .Config.Resolver }};{{ end }}
+
+    # Obtain client IP from frontend's X-Forward-For header
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive off;
 
     # Put all data into the working directory
     access_log             {{ .Config.WorkingDir }}/access.log main gzip;
@@ -46,6 +51,7 @@ http {
     scgi_temp_path         {{ .Config.WorkingDir }}/tmp_scgi 1 2;
 
     # Configure ingresses
+    {{ $defaultAllow := .Config.DefaultAllow }}
     {{ $port := .Config.IngressPort }}
     {{ range $entry := .Entries }}
     # Start entry
@@ -53,10 +59,11 @@ http {
         listen {{ $port }};
         server_name {{ $entry.Host }};
 
-        # Obtain client IP from ELB's X-Forward-For header
-        set_real_ip_from 0.0.0.0/0;
-        real_ip_header X-Forwarded-For;
-        real_ip_recursive off;
+        # Restrict clients
+        {{ if $defaultAllow }}allow {{ $defaultAllow }};{{ end }}
+        allow 127.0.0.1;
+        {{ if $entry.Allow }}allow {{ $entry.Allow }};{{ end }}
+        deny all;
 
         location {{ $entry.Path }} {
             proxy_pass http://{{ $entry.ServiceName }}:{{ $entry.ServicePort }};
@@ -73,7 +80,7 @@ http {
         }
     }
 
-    # Status pages
+    # Status port. This should be firewalled to only allow internal access.
     server {
         listen {{ .Config.StatusPort }} default_server reuseport;
 


### PR DESCRIPTION
Deny everything but localhost by default.

Add support for `sky.uk/allow` annotation on ingress resources.

Add support for a default allow range on ingress, to support blanket
internal access.