### PR TITLE
Add ingress names to the nginx.conf

### DIFF
--- a/ingress/controller.go
+++ b/ingress/controller.go
@@ -100,6 +100,7 @@ func (c *controller) updateLoadBalancer() error {
 				serviceName := fmt.Sprintf("%s.%s.%s",
 					path.Backend.ServiceName, ingress.Namespace, c.serviceDomain)
 				entry := types.LoadBalancerEntry{
+					Name:        ingress.Namespace + "/" + ingress.Name,
 					Host:        rule.Host,
 					Path:        path.Path,
 					ServiceName: serviceName,

--- a/ingress/controller_test.go
+++ b/ingress/controller_test.go
@@ -242,6 +242,7 @@ func sendUpdate(watcher k8s.Watcher, value interface{}, d time.Duration) error {
 
 func createLbEntriesFixture() types.LoadBalancerUpdate {
 	return types.LoadBalancerUpdate{Entries: []types.LoadBalancerEntry{types.LoadBalancerEntry{
+		Name:        ingressNamespace + "/" + ingressName,
 		Host:        ingressHost,
 		Path:        ingressPath,
 		ServiceName: ingressSvcName + "." + ingressNamespace + "." + serviceDomain,
@@ -253,6 +254,7 @@ func createLbEntriesFixture() types.LoadBalancerUpdate {
 const (
 	ingressHost      = "foo.sky.com"
 	ingressPath      = "/foo"
+	ingressName      = "foo-ingress"
 	ingressSvcName   = "foo-svc"
 	ingressSvcPort   = 80
 	ingressNamespace = "happysky"
@@ -271,7 +273,7 @@ func createIngressesFixture() []k8s.Ingress {
 	return []k8s.Ingress{
 		k8s.Ingress{
 			ObjectMeta: k8s.ObjectMeta{
-				Name:        "foo-ingress",
+				Name:        ingressName,
 				Namespace:   ingressNamespace,
 				Annotations: map[string]string{ingressAllowAnnotation: ingressAllow},
 			},

--- a/ingress/nginx/nginx.go
+++ b/ingress/nginx/nginx.go
@@ -155,7 +155,7 @@ func (lb *nginxLoadBalancer) Stop() error {
 }
 
 func (lb *nginxLoadBalancer) Update(entries types.LoadBalancerUpdate) (bool, error) {
-	updated, err := lb.update(entries)
+	updated, err := lb.update(entries.SortedByName())
 	if err != nil {
 		return false, fmt.Errorf("unable to update nginx: %v", err)
 	}

--- a/ingress/nginx/nginx.tmpl
+++ b/ingress/nginx/nginx.tmpl
@@ -55,6 +55,7 @@ http {
     {{ $port := .Config.IngressPort }}
     {{ range $entry := .Entries }}
     # Start entry
+    # {{ $entry.Name }}
     server {
         listen {{ $port }};
         server_name {{ $entry.Host }};

--- a/ingress/types/lb_entry.go
+++ b/ingress/types/lb_entry.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"sort"
+
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -11,6 +13,8 @@ type LoadBalancerUpdate struct {
 
 // LoadBalancerEntry describes the ingress for a single host, path, and service.
 type LoadBalancerEntry struct {
+	// Name of the entry.
+	Name string
 	// Host is the fully qualified domain name used for external access.
 	Host string
 	// Path is the url path after the hostname.
@@ -54,3 +58,17 @@ func (entry LoadBalancerEntry) ValidateEntry() bool {
 	}
 	return true
 }
+
+// SortedByName returns the update with entries ordered by their Name.
+func (u LoadBalancerUpdate) SortedByName() LoadBalancerUpdate {
+	sortedEntries := make([]LoadBalancerEntry, len(u.Entries))
+	copy(sortedEntries, u.Entries)
+	sort.Sort(byName(sortedEntries))
+	return LoadBalancerUpdate{Entries: sortedEntries}
+}
+
+type byName []LoadBalancerEntry
+
+func (a byName) Len() int           { return len(a) }
+func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byName) Less(i, j int) bool { return a[i].Name < a[j].Name }


### PR DESCRIPTION
So we can easily find the ingress in kubernetes that generated the
entry.

This also changes it to sort by name so our config order should remain
relatively stable (not be reordered whenever there is a new or changed
ingress).