### PR TITLE
Make nginx log level configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC64107
 						gettext-base \
 						curl \
 						dnsutils \
+						vim-tiny \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -30,6 +30,7 @@ var (
 	nginxWorkerProcesses   int
 	nginxWorkerConnections int
 	nginxKeepAliveSeconds  int
+	nginxLogLevel          string
 )
 
 func init() {
@@ -47,6 +48,7 @@ func init() {
 		defaultNginxWorkers           = 1
 		defaultNginxWorkerConnections = 1024
 		defaultNginxKeepAliveSeconds  = 65
+		defaultNginxLogLevel          = "info"
 	)
 
 	flag.BoolVar(&debug, "debug", false,
@@ -80,6 +82,8 @@ func init() {
 		"Max number of connections per nginx worker. Includes both client and proxy connections.")
 	flag.IntVar(&nginxKeepAliveSeconds, "nginx-keepalive-seconds", defaultNginxKeepAliveSeconds,
 		"Keep alive time for persistent client connections to nginx.")
+	flag.StringVar(&nginxLogLevel, "nginx-loglevel", defaultNginxLogLevel,
+		"Log level for nginx. See http://nginx.org/en/docs/ngx_core_module.html#error_log for levels.")
 }
 
 func main() {

--- a/ingress/nginx/nginx.go
+++ b/ingress/nginx/nginx.go
@@ -33,6 +33,7 @@ type Conf struct {
 	IngressPort       int
 	Resolver          string
 	DefaultAllow      string
+	LogLevel          string
 }
 
 // Signaller interface around signalling the loadbalancer process
@@ -78,6 +79,10 @@ func (lb *nginxLoadBalancer) nginxConfFile() string {
 // NewNginxLB creates a new LoadBalancer
 func NewNginxLB(nginxConf Conf) types.LoadBalancer {
 	nginxConf.WorkingDir = strings.TrimSuffix(nginxConf.WorkingDir, "/")
+	if nginxConf.LogLevel == "" {
+		nginxConf.LogLevel = "warn"
+	}
+
 	return &nginxLoadBalancer{
 		Conf:       nginxConf,
 		signaller:  &osSignaller{},

--- a/ingress/nginx/nginx.tmpl
+++ b/ingress/nginx/nginx.tmpl
@@ -1,11 +1,8 @@
 worker_processes  {{ .Config.WorkerProcesses }};
 daemon off;
 
-error_log stderr warn;
+error_log stderr {{ .Config.LogLevel }};
 pid {{ .Config.WorkingDir }}/nginx.pid;
-
-# Set large max limit on number of open connections / files.
-worker_rlimit_nofile 131072;
 
 events {
     # Accept connections as fast as possible.
@@ -72,6 +69,8 @@ http {
     }
     # End entry
     {{ end }}
+
+    # End ingresses
 
     # Default backend
     server {


### PR DESCRIPTION
Using `info` also revealed that the container is unable to set file
limits. This is handled by the docker service, so I've removed the
setting.