### PR TITLE
Allow annotation replaces default nginx allow

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -66,7 +66,7 @@ func init() {
 	flag.IntVar(&ingressHealthPort, "ingress-health-port", defaultIngressHealthPort,
 		"Port for ingress /health and /status pages. Should be used by frontends to determine if ingress is available.")
 	flag.StringVar(&ingressAllow, "ingress-allow", defaultIngressAllow,
-		"Source IP or CIDR to allow ingress access by default. This is in addition to the sky.uk/allow "+
+		"Source IP or CIDR to allow ingress access by default. This is overridden by the sky.uk/allow "+
 			"annotation on ingress resources. Leave empty to deny all access by default.")
 	flag.IntVar(&healthPort, "health-port", defaultHealthPort,
 		"Port for checking the health of the ingress controller on /health. Also provides /debug/pprof.")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -9,6 +9,8 @@ import (
 
 	"fmt"
 
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/sky-uk/feed/k8s"
 	"github.com/sky-uk/feed/util"
@@ -125,7 +127,7 @@ func (c *controller) updateIngresses() error {
 						Path:           path.Path,
 						ServiceAddress: address,
 						ServicePort:    int32(path.Backend.ServicePort.IntValue()),
-						Allow:          ingress.Annotations[ingressAllowAnnotation],
+						Allow:          strings.Split(ingress.Annotations[ingressAllowAnnotation], ","),
 					}
 
 					if !entry.isEmpty() {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -7,6 +7,8 @@ import (
 
 	"fmt"
 
+	"strings"
+
 	"github.com/sky-uk/feed/k8s"
 	fake "github.com/sky-uk/feed/util/test"
 	"github.com/stretchr/testify/assert"
@@ -352,7 +354,7 @@ func createLbEntriesFixture() IngressUpdate {
 		Path:           ingressPath,
 		ServiceAddress: serviceIP,
 		ServicePort:    ingressSvcPort,
-		Allow:          ingressAllow,
+		Allow:          strings.Split(ingressAllow, ","),
 	}}}
 }
 
@@ -363,7 +365,7 @@ const (
 	ingressSvcName   = "foo-svc"
 	ingressSvcPort   = 80
 	ingressNamespace = "happysky"
-	ingressAllow     = "10.82.0.0/16"
+	ingressAllow     = "10.82.0.0/16,10.44.0.0/16"
 	serviceIP        = "10.254.0.82"
 )
 

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -19,8 +19,8 @@ type IngressEntry struct {
 	ServiceAddress string
 	// ServicePort is the port to proxy traffic to.
 	ServicePort int32
-	// SourceRange is the ip or cidr that is allowed to access the service.
-	Allow string
+	// Allow are the ips or cidrs that are allowed to access the service.
+	Allow []string
 }
 
 // isEmpty returns true if Host, ServiceAddress, or ServicePort are empty.

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -48,9 +48,10 @@ http {
         server_name {{ $entry.Host }};
 
         # Restrict clients
-        {{ if $defaultAllow }}allow {{ $defaultAllow }};{{ end }}
         allow 127.0.0.1;
-        {{ if $entry.Allow }}allow {{ $entry.Allow }};{{ end }}
+        {{ if $entry.Allow }}{{ range $entry.Allow }}allow {{ . }};
+        {{ end }}{{ else if $defaultAllow }}allow {{ $defaultAllow }};
+        {{ end }}
         deny all;
 
         location {{ if $entry.Path }}{{ $entry.Path }}{{ end }} {


### PR DESCRIPTION
Also add support for comma delimited allows, which is necessary now that
we can't combine with a default allow (such as for external access
combined with internal).