### PR TITLE
Strip the ingress path prefix

### DIFF
--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -214,8 +214,22 @@ func (lb *nginxLoadBalancer) createConfig(update controller.IngressUpdate) ([]by
 		return nil, err
 	}
 
+	var templateEntries []controller.IngressEntry
+	for _, entry := range update.Entries {
+		fmt.Printf("%v\n", entry)
+		trimmedPath := strings.TrimSuffix(strings.TrimPrefix(entry.Path, "/"), "/")
+		if len(trimmedPath) == 0 {
+			entry.Path = "/"
+		} else {
+			entry.Path = fmt.Sprintf("/%s/", trimmedPath)
+		}
+		templateEntries = append(templateEntries, entry)
+	}
+
+	fmt.Printf("%d\n", len(templateEntries))
+
 	var output bytes.Buffer
-	err = tmpl.Execute(&output, loadBalancerTemplate{Config: lb.Conf, Entries: update.Entries})
+	err = tmpl.Execute(&output, loadBalancerTemplate{Config: lb.Conf, Entries: templateEntries})
 
 	if err != nil {
 		return []byte{}, fmt.Errorf("Unable to execute nginx config duration. It will be out of date: %v", err)

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -53,8 +53,8 @@ http {
         {{ if $entry.Allow }}allow {{ $entry.Allow }};{{ end }}
         deny all;
 
-        location {{ if $entry.Path }}{{ $entry.Path }}{{ else }}/{{ end }} {
-            proxy_pass http://{{ $entry.ServiceAddress }}:{{ $entry.ServicePort }};
+        location {{ if $entry.Path }}{{ $entry.Path }}{{ end }} {
+            proxy_pass http://{{ $entry.ServiceAddress }}:{{ $entry.ServicePort }}/;
         }
     }
     # End entry

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -182,8 +182,8 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"        allow 10.82.0.0/16;\n" +
 					"        deny all;\n" +
 					"\n" +
-					"        location /path {\n" +
-					"            proxy_pass http://service:9090;\n" +
+					"        location /path/ {\n" +
+					"            proxy_pass http://service:9090/;\n" +
 					"        }\n" +
 					"    }\n" +
 					"    ",
@@ -212,8 +212,8 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"        \n" +
 					"        deny all;\n" +
 					"\n" +
-					"        location /bar {\n" +
-					"            proxy_pass http://lala:8080;\n" +
+					"        location /bar/ {\n" +
+					"            proxy_pass http://lala:8080/;\n" +
 					"        }\n" +
 					"    }\n" +
 					"    ",
@@ -257,7 +257,7 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"        deny all;\n" +
 					"\n" +
 					"        location / {\n" +
-					"            proxy_pass http://foo:8080;\n" +
+					"            proxy_pass http://foo:8080/;\n" +
 					"        }\n" +
 					"    }\n" +
 					"    ",
@@ -273,7 +273,7 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"        deny all;\n" +
 					"\n" +
 					"        location / {\n" +
-					"            proxy_pass http://foo:8080;\n" +
+					"            proxy_pass http://foo:8080/;\n" +
 					"        }\n" +
 					"    }\n" +
 					"    ",
@@ -289,19 +289,51 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"        deny all;\n" +
 					"\n" +
 					"        location / {\n" +
-					"            proxy_pass http://foo:8080;\n" +
+					"            proxy_pass http://foo:8080/;\n" +
 					"        }\n" +
 					"    }\n" +
 					"    ",
 			},
 		},
-		// Check empty path works.
+		// Check path slashes are added correctly
 		{
 			[]controller.IngressEntry{
 				{
 					Host:           "chris.com",
 					Name:           "chris-ingress",
 					Path:           "",
+					ServiceAddress: "service",
+					ServicePort:    9090,
+					Allow:          "10.82.0.0/16",
+				},
+				{
+					Host:           "chris.com",
+					Name:           "chris-ingress",
+					Path:           "/prefix-with-slash/",
+					ServiceAddress: "service",
+					ServicePort:    9090,
+					Allow:          "10.82.0.0/16",
+				},
+				{
+					Host:           "chris.com",
+					Name:           "chris-ingress",
+					Path:           "prefix-without-preslash/",
+					ServiceAddress: "service",
+					ServicePort:    9090,
+					Allow:          "10.82.0.0/16",
+				},
+				{
+					Host:           "chris.com",
+					Name:           "chris-ingress",
+					Path:           "/prefix-without-postslash",
+					ServiceAddress: "service",
+					ServicePort:    9090,
+					Allow:          "10.82.0.0/16",
+				},
+				{
+					Host:           "chris.com",
+					Name:           "chris-ingress",
+					Path:           "prefix-without-anyslash",
 					ServiceAddress: "service",
 					ServicePort:    9090,
 					Allow:          "10.82.0.0/16",
@@ -320,7 +352,71 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"        deny all;\n" +
 					"\n" +
 					"        location / {\n" +
-					"            proxy_pass http://service:9090;\n" +
+					"            proxy_pass http://service:9090/;\n" +
+					"        }\n" +
+					"    }\n" +
+					"    ",
+				"   # chris-ingress\n" +
+					"    server {\n" +
+					"        listen 9090;\n" +
+					"        server_name chris.com;\n" +
+					"\n" +
+					"        # Restrict clients\n" +
+					"        allow 10.50.0.0/16;\n" +
+					"        allow 127.0.0.1;\n" +
+					"        allow 10.82.0.0/16;\n" +
+					"        deny all;\n" +
+					"\n" +
+					"        location /prefix-with-slash/ {\n" +
+					"            proxy_pass http://service:9090/;\n" +
+					"        }\n" +
+					"    }\n" +
+					"    ",
+				"   # chris-ingress\n" +
+					"    server {\n" +
+					"        listen 9090;\n" +
+					"        server_name chris.com;\n" +
+					"\n" +
+					"        # Restrict clients\n" +
+					"        allow 10.50.0.0/16;\n" +
+					"        allow 127.0.0.1;\n" +
+					"        allow 10.82.0.0/16;\n" +
+					"        deny all;\n" +
+					"\n" +
+					"        location /prefix-without-preslash/ {\n" +
+					"            proxy_pass http://service:9090/;\n" +
+					"        }\n" +
+					"    }\n" +
+					"    ",
+				"   # chris-ingress\n" +
+					"    server {\n" +
+					"        listen 9090;\n" +
+					"        server_name chris.com;\n" +
+					"\n" +
+					"        # Restrict clients\n" +
+					"        allow 10.50.0.0/16;\n" +
+					"        allow 127.0.0.1;\n" +
+					"        allow 10.82.0.0/16;\n" +
+					"        deny all;\n" +
+					"\n" +
+					"        location /prefix-without-postslash/ {\n" +
+					"            proxy_pass http://service:9090/;\n" +
+					"        }\n" +
+					"    }\n" +
+					"    ",
+				"   # chris-ingress\n" +
+					"    server {\n" +
+					"        listen 9090;\n" +
+					"        server_name chris.com;\n" +
+					"\n" +
+					"        # Restrict clients\n" +
+					"        allow 10.50.0.0/16;\n" +
+					"        allow 127.0.0.1;\n" +
+					"        allow 10.82.0.0/16;\n" +
+					"        deny all;\n" +
+					"\n" +
+					"        location /prefix-without-anyslash/ {\n" +
+					"            proxy_pass http://service:9090/;\n" +
 					"        }\n" +
 					"    }\n" +
 					"    ",


### PR DESCRIPTION
E.g. if someone hits `sky.com/commerce/verification-app/private/ready` it will
proxy to `verification-app/private/ready`, stripping the prefix.

Also fix the location to always have trailing slashes (otherwise it
doesn't work with path prefixes).