### PR TITLE
Improve health logging so it doesn't spam

### DIFF
--- a/cmd/feed-dns/main.go
+++ b/cmd/feed-dns/main.go
@@ -39,7 +39,7 @@ func main() {
 	client := cmd.CreateK8sClient(caCertFile, tokenFile, apiServer)
 	controller := dns.New(client)
 
-	cmd.ConfigureHealthPort(controller, healthPort)
+	cmd.AddHealthPort(controller, healthPort)
 	cmd.AddSignalHandler(controller)
 
 	err := controller.Start()

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -6,6 +6,8 @@ import (
 
 	_ "net/http/pprof"
 
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/elb"
@@ -103,7 +105,7 @@ func main() {
 		Updaters:         updaters,
 	})
 
-	cmd.ConfigureHealthPort(controller, healthPort)
+	cmd.AddHealthPort(controller, healthPort)
 	cmd.AddSignalHandler(controller)
 
 	err := controller.Start()
@@ -112,6 +114,8 @@ func main() {
 		os.Exit(-1)
 	}
 	log.Info("Controller started")
+
+	cmd.AddUnhealthyLogger(controller, time.Second*5)
 
 	select {}
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -200,7 +200,7 @@ func (c *controller) Health() error {
 
 	for _, u := range c.updaters {
 		if err := u.Health(); err != nil {
-			return fmt.Errorf("unhealthy %v: %v", u, err)
+			return fmt.Errorf("%v: %v", u, err)
 		}
 	}
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -159,7 +159,7 @@ func TestControllerIsUnhealthyIfUpdaterIsUnhealthy(t *testing.T) {
 	updater.On("Update", mock.Anything).Return(nil)
 	// first return healthy, then unhealthy for lb
 	updater.On("Health").Return(nil).Once()
-	lbErr := fmt.Errorf("unhealthy FakeUpdater: dead")
+	lbErr := fmt.Errorf("FakeUpdater: dead")
 	updater.On("Health").Return(fmt.Errorf("dead")).Once()
 
 	assert.NoError(controller.Start())

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -208,7 +208,7 @@ func handleLongPoll(r io.Reader, updateCh chan<- interface{}) {
 
 	for scanner.Scan() {
 		event := scanner.Text()
-		log.Infof("Received event %s", event)
+		log.Debugf("Received event %s", event)
 		updateCh <- struct{}{}
 	}
 

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -216,7 +216,6 @@ func (lb *nginxLoadBalancer) createConfig(update controller.IngressUpdate) ([]by
 
 	var templateEntries []controller.IngressEntry
 	for _, entry := range update.Entries {
-		fmt.Printf("%v\n", entry)
 		trimmedPath := strings.TrimSuffix(strings.TrimPrefix(entry.Path, "/"), "/")
 		if len(trimmedPath) == 0 {
 			entry.Path = "/"
@@ -225,8 +224,6 @@ func (lb *nginxLoadBalancer) createConfig(update controller.IngressUpdate) ([]by
 		}
 		templateEntries = append(templateEntries, entry)
 	}
-
-	fmt.Printf("%d\n", len(templateEntries))
 
 	var output bytes.Buffer
 	err = tmpl.Execute(&output, loadBalancerTemplate{Config: lb.Conf, Entries: templateEntries})


### PR DESCRIPTION
Use a periodic logger to check health. Otherwise our log gets spammed
when unhealthy by external calls to the health check endpoint (5s in
kubernetes).