### PR TITLE
Fix broken nginx.conf if no allow annotation

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -103,6 +103,7 @@ func main() {
 	controller := controller.New(controller.Config{
 		KubernetesClient: client,
 		Updaters:         updaters,
+		DefaultAllow:     ingressAllow,
 	})
 
 	cmd.AddHealthPort(controller, healthPort)
@@ -130,7 +131,6 @@ func createIngressUpdaters() []controller.Updater {
 		WorkerConnections: nginxWorkerConnections,
 		KeepAliveSeconds:  nginxKeepAliveSeconds,
 		HealthPort:        ingressHealthPort,
-		DefaultAllow:      ingressAllow,
 	})
 	return []controller.Updater{frontend, proxy}
 }

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -31,7 +31,6 @@ type Conf struct {
 	KeepAliveSeconds  int
 	HealthPort        int
 	IngressPort       int
-	DefaultAllow      string
 	LogLevel          string
 }
 

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -38,7 +38,6 @@ http {
     scgi_temp_path         {{ .Config.WorkingDir }}/tmp_scgi 1 2;
 
     # Configure ingresses
-    {{ $defaultAllow := .Config.DefaultAllow }}
     {{ $port := .Config.IngressPort }}
     {{ range $entry := .Entries }}
     # Start entry
@@ -49,8 +48,7 @@ http {
 
         # Restrict clients
         allow 127.0.0.1;
-        {{ if $entry.Allow }}{{ range $entry.Allow }}allow {{ . }};
-        {{ end }}{{ else if $defaultAllow }}allow {{ $defaultAllow }};
+        {{ range $entry.Allow }}allow {{ . }};
         {{ end }}
         deny all;
 


### PR DESCRIPTION
It was broken if allow annotation isn't specified. This change fixes
that. Basically, it was doing a split on an empty string, which produces
[]string{""}. This causes an `allow  ;` entry in nginx since it was
simply expanding the slice with `range`.

It also moves default allow into the controller, since everything that
gets an ingress entry should see the default allow as well. It's not
nginx specific.