### PR TITLE
Add upstreams for persistent backend connections

### DIFF
--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -1,6 +1,9 @@
 package controller
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // IngressUpdate data
 type IngressUpdate struct {
@@ -13,28 +16,29 @@ type IngressEntry struct {
 	Name string
 	// Host is the fully qualified domain name used for external access.
 	Host string
-	// Path is the url path after the hostname.
+	// Path is the url path after the hostname. Must be non-empty.
 	Path string
-	// Service is a routable address for the Kubernetes backend service to proxy traffic to.
+	// ServiceAddress is a routable address for the Kubernetes backend service to proxy traffic to.
+	// Must be non-empty.
 	ServiceAddress string
-	// ServicePort is the port to proxy traffic to.
+	// ServicePort is the port to proxy traffic to. Must be non-zero.
 	ServicePort int32
 	// Allow are the ips or cidrs that are allowed to access the service.
 	Allow []string
 }
 
-// isEmpty returns true if Host, ServiceAddress, or ServicePort are empty.
-func (entry IngressEntry) isEmpty() bool {
+// validate returns error if entry has invalid fields.
+func (entry IngressEntry) validate() error {
 	if entry.Host == "" {
-		return true
+		return fmt.Errorf("%s had empty Host", entry.Name)
 	}
 	if entry.ServiceAddress == "" {
-		return true
+		return fmt.Errorf("%s had empty ServiceAddress", entry.Name)
 	}
 	if entry.ServicePort == 0 {
-		return true
+		return fmt.Errorf("%s had 0 ServicePort", entry.Name)
 	}
-	return false
+	return nil
 }
 
 // SortedByName returns the update with entries ordered by their Name.

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -148,7 +148,7 @@ func (c *client) watch(resourcePath string) Watcher {
 		for watch(w, request) {
 		}
 
-		log.Debug("Watch %s has stopped", resourcePath)
+		log.Debugf("Watch %s has stopped", resourcePath)
 	}()
 
 	return w

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -18,18 +18,22 @@ events {
 http {
     default_type text/html;
 
-    # Keep alive time for client connections
-    keepalive_timeout {{ .Config.KeepAliveSeconds }}s;
+    # Keep alive time for client connections. Don't limit by number of requests.
+    keepalive_timeout {{ .Config.KeepaliveSeconds }}s;
+    keepalive_requests 2147483647;
 
-    # Optimize for latency over throughput for persistent connections
+    # Optimize for latency over throughput for persistent connections.
     tcp_nodelay on;
+
+    # Disable nginx version leakage to external clients.
+    server_tokens off;
 
     # Obtain client IP from frontend's X-Forward-For header
     set_real_ip_from 0.0.0.0/0;
     real_ip_header X-Forwarded-For;
     real_ip_recursive off;
 
-    # Put all data into the working directory
+    # Put all data into the working directory.
     access_log             off;
     client_body_temp_path  {{ .Config.WorkingDir }}/tmp_client_body 1 2;
     proxy_temp_path        {{ .Config.WorkingDir }}/tmp_proxy 1 2;
@@ -39,9 +43,16 @@ http {
 
     # Configure ingresses
     {{ $port := .Config.IngressPort }}
+    {{ $keepalive := .Config.BackendKeepalives }}
+    {{ $keepaliveSeconds := .Config.BackendKeepaliveSeconds }}
     {{ range $entry := .Entries }}
     # Start entry
     # {{ $entry.Name }}
+    upstream {{ $entry.UpstreamID }} {
+        server {{ $entry.ServiceAddress }}:{{ $entry.ServicePort }};
+        keepalive {{ $keepalive }};
+    }
+
     server {
         listen {{ $port }};
         server_name {{ $entry.Host }};
@@ -53,7 +64,29 @@ http {
         deny all;
 
         location {{ if $entry.Path }}{{ $entry.Path }}{{ end }} {
-            proxy_pass http://{{ $entry.ServiceAddress }}:{{ $entry.ServicePort }}/;
+            # Strip location path when proxying.
+            proxy_pass http://{{ $entry.UpstreamID }}/;
+
+            # Enable keepalive to backend.
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+
+            # Add X-Forwarded-For and X-Original-URI for proxy information.
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Original-URI $request_uri;
+
+            # Timeout faster than the default 60s on initial connect.
+            proxy_connect_timeout 10s;
+
+            # Close proxy connections after backend keepalive time.
+            proxy_read_timeout {{ $keepaliveSeconds }}s;
+            proxy_send_timeout {{ $keepaliveSeconds }}s;
+
+            # Disable buffering, as we'll be interacting with ELBs with http listeners, which we assume will
+            # quickly consume and generate responses and requests.
+            # This should be enabled if nginx will directly serve traffic externally to unknown clients.
+            proxy_buffering off;
+            proxy_request_buffering off;
         }
     }
     # End entry


### PR DESCRIPTION
Brings new config:
- Backend keepalive number and keepalive times

And based on internal production nginx:
- Fix nginx keepalive_requests for client requests
- Disable buffering for use with ELB http listeners