### PR TITLE
Track unhealthy time in `/metrics`

### DIFF
--- a/controller/updater.go
+++ b/controller/updater.go
@@ -8,6 +8,7 @@ type Updater interface {
 	Stop() error
 	// Update the ingress updater configuration.
 	Update(IngressUpdate) error
-	// Health returns nil if healthy, otherwise an error.
+	// Health returns nil if healthy, otherwise an error. Should be fast to respond, as it
+	// may be called often. Any long running checks should be done separately.
 	Health() error
 }


### PR DESCRIPTION
So we can alert when the ingress controller is unhealthy.
    
Adds `feed_ingress_unhealthy_time` which is the amount of time in
seconds it has been unhealthy for.

This depends on #57