### PR TITLE
Add trusted frontends for determining client ip

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -105,7 +105,7 @@ func (c *controller) handleUpdates() {
 
 func (c *controller) updateIngresses() error {
 	ingresses, err := c.client.GetIngresses()
-	log.Infof("Found %d ingress(es)", len(ingresses))
+	log.Infof("Found %d ingresses", len(ingresses))
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (c *controller) updateIngresses() error {
 		}
 	}
 
-	log.Infof("Updating with %d ingress entry(s), skipped %d invalid", len(entries), skipped)
+	log.Infof("Updating with %d entries, skipping %d invalid", len(entries), skipped)
 	update := IngressUpdate{Entries: entries}
 	for _, u := range c.updaters {
 		if err := u.Update(update); err != nil {

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -32,6 +32,7 @@ type Conf struct {
 	BackendKeepalives       int
 	BackendKeepaliveSeconds int
 	HealthPort              int
+	TrustedFrontends        []string
 	IngressPort             int
 	LogLevel                string
 }
@@ -68,7 +69,7 @@ type nginxLoadBalancer struct {
 
 // Used for generating nginx config
 type loadBalancerTemplate struct {
-	Config  Conf
+	Conf
 	Entries []nginxEntry
 }
 
@@ -238,7 +239,7 @@ func (lb *nginxLoadBalancer) createConfig(update controller.IngressUpdate) ([]by
 	}
 
 	var output bytes.Buffer
-	err = tmpl.Execute(&output, loadBalancerTemplate{Config: lb.Conf, Entries: entries})
+	err = tmpl.Execute(&output, loadBalancerTemplate{Conf: lb.Conf, Entries: entries})
 
 	if err != nil {
 		return []byte{}, fmt.Errorf("Unable to execute nginx config duration. It will be out of date: %v", err)

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -1,15 +1,15 @@
-worker_processes  {{ .Config.WorkerProcesses }};
+worker_processes  {{ .WorkerProcesses }};
 daemon off;
 
-error_log stderr {{ .Config.LogLevel }};
-pid {{ .Config.WorkingDir }}/nginx.pid;
+error_log stderr {{ .LogLevel }};
+pid {{ .WorkingDir }}/nginx.pid;
 
 events {
     # Accept connections as fast as possible.
     multi_accept on;
     # Includes both proxy and client connections.
     # So e.g. 4096 = 2048 persistent client connections to backends per worker.
-    worker_connections {{ .Config.WorkerConnections }};
+    worker_connections {{ .WorkerConnections }};
     # Use most optimal non-blocking selector on linux.
     # Should be selected by default on linux, we just make it explicit here.
     use epoll;
@@ -19,7 +19,7 @@ http {
     default_type text/html;
 
     # Keep alive time for client connections. Don't limit by number of requests.
-    keepalive_timeout {{ .Config.KeepaliveSeconds }}s;
+    keepalive_timeout {{ .KeepaliveSeconds }}s;
     keepalive_requests 2147483647;
 
     # Optimize for latency over throughput for persistent connections.
@@ -29,22 +29,23 @@ http {
     server_tokens off;
 
     # Obtain client IP from frontend's X-Forward-For header
-    set_real_ip_from 0.0.0.0/0;
+{{ range .TrustedFrontends }}    set_real_ip_from {{ . }};
+{{ end }}
     real_ip_header X-Forwarded-For;
-    real_ip_recursive off;
+    real_ip_recursive on;
 
     # Put all data into the working directory.
     access_log             off;
-    client_body_temp_path  {{ .Config.WorkingDir }}/tmp_client_body 1 2;
-    proxy_temp_path        {{ .Config.WorkingDir }}/tmp_proxy 1 2;
-    fastcgi_temp_path      {{ .Config.WorkingDir }}/tmp_fastcgi 1 2;
-    uwsgi_temp_path        {{ .Config.WorkingDir }}/tmp_uwsgi 1 2;
-    scgi_temp_path         {{ .Config.WorkingDir }}/tmp_scgi 1 2;
+    client_body_temp_path  {{ .WorkingDir }}/tmp_client_body 1 2;
+    proxy_temp_path        {{ .WorkingDir }}/tmp_proxy 1 2;
+    fastcgi_temp_path      {{ .WorkingDir }}/tmp_fastcgi 1 2;
+    uwsgi_temp_path        {{ .WorkingDir }}/tmp_uwsgi 1 2;
+    scgi_temp_path         {{ .WorkingDir }}/tmp_scgi 1 2;
 
     # Configure ingresses
-    {{ $port := .Config.IngressPort }}
-    {{ $keepalive := .Config.BackendKeepalives }}
-    {{ $keepaliveSeconds := .Config.BackendKeepaliveSeconds }}
+    {{ $port := .IngressPort }}
+    {{ $keepalive := .BackendKeepalives }}
+    {{ $keepaliveSeconds := .BackendKeepaliveSeconds }}
     {{ range $entry := .Entries }}
     # Start entry
     # {{ $entry.Name }}
@@ -96,7 +97,7 @@ http {
 
     # Default backend
     server {
-        listen {{ .Config.IngressPort }} default_server;
+        listen {{ .IngressPort }} default_server;
         location / {
             return 404;
         }
@@ -104,7 +105,7 @@ http {
 
     # Status port. This should be firewalled to only allow internal access.
     server {
-        listen {{ .Config.HealthPort }} default_server reuseport;
+        listen {{ .HealthPort }} default_server reuseport;
 
         location /health {
             access_log off;

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -147,6 +147,55 @@ func TestCanSetLogLevel(t *testing.T) {
 	}
 }
 
+func TestTrustedFrontendsSetsUpClientIPCorrectly(t *testing.T) {
+	assert := assert.New(t)
+	tmpDir := setupWorkDir(t)
+	defer os.Remove(tmpDir)
+
+	multipleTrusted := newConf(tmpDir, fakeNginx)
+	multipleTrusted.TrustedFrontends = []string{"10.50.185.0/24", "10.82.0.0/16"}
+
+	var tests = []struct {
+		name           string
+		lbConf         Conf
+		expectedOutput string
+	}{
+		{
+			"multiple trusted frontends works",
+			multipleTrusted,
+			`    # Obtain client IP from frontend's X-Forward-For header
+    set_real_ip_from 10.50.185.0/24;
+    set_real_ip_from 10.82.0.0/16;
+
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;`,
+		},
+		{
+			"no trusted frontends works",
+			newConf(tmpDir, fakeNginx),
+			`    # Obtain client IP from frontend's X-Forward-For header
+
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;`,
+		},
+	}
+
+	for _, test := range tests {
+		lb, _ := newLbWithConf(test.lbConf)
+
+		assert.NoError(lb.Start())
+		err := lb.Update(controller.IngressUpdate{})
+		assert.NoError(err)
+
+		config, err := ioutil.ReadFile(tmpDir + "/nginx.conf")
+		assert.NoError(err)
+		configContents := string(config)
+
+		assert.Contains(configContents, test.expectedOutput, test.name)
+
+	}
+}
+
 func TestNginxConfigUpdates(t *testing.T) {
 	assert := assert.New(t)
 	tmpDir := setupWorkDir(t)


### PR DESCRIPTION
Add flag `-nginx-trusted-frontends`, used by nginx to determine the
client ip for allow/deny directives.