### PR TITLE
Unhealthy if nginx configuration fails to load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,11 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC64107
 
 WORKDIR /
 COPY feed-ingress /
+
 RUN mkdir /nginx
-RUN chown nginx:nginx /nginx
+COPY nginx.tmpl /nginx/
+RUN chown -R nginx:nginx /nginx
 
 USER nginx
-COPY nginx.tmpl /nginx/
 
 ENTRYPOINT ["/feed-ingress", "-nginx-workdir", "/nginx"]

--- a/nginx/fake_nginx_failing_reload.sh
+++ b/nginx/fake_nginx_failing_reload.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo $0 $@
+if [[ "$1" == "-t" ]]; then
+    echo "Config check failed" >&2
+    exit 1
+fi
+
+sleep 0.5

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -39,7 +39,7 @@ func AddHealthPort(pulse Pulse, healthPort int) {
 func healthHandler(pulse Pulse) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := pulse.Health(); err != nil {
-			w.WriteHeader(http.StatusServiceUnavailable)
+			w.WriteHeader(http.StatusInternalServerError)
 			io.WriteString(w, fmt.Sprintf("%v\n", err))
 			return
 		}


### PR DESCRIPTION
This notifies us if something goes wrong with nginx.conf, which has come
up several times in testing.

If nginx.conf is invalid, it will cause `feed-ingress` to become
unhealthy.