### PR TITLE
Filter out ingress updates that have an invalid hostname

### DIFF
--- a/dns/r53/client.go
+++ b/dns/r53/client.go
@@ -8,23 +8,47 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
+// Route53Client is the public interface
+type Route53Client interface {
+	GetHostedZoneDomain() (string, error)
+	UpdateRecordSets(changes []*route53.Change) error
+	GetARecords() ([]*route53.ResourceRecordSet, error)
+}
+
+// r53 interface exposes the subset of methods we use of the aws sdk
+type r53 interface {
+	GetHostedZone(input *route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error)
+	ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error)
+	ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
+}
+
 // Route53Client enables interaction with aws route53
-type Route53Client struct {
-	client     route53.Route53
+type dns struct {
+	r53        r53
 	hostedZone string
 }
 
 // New creates a route53 client used to interact with aws
 func New(region string, hostedZone string) Route53Client {
-	return Route53Client{
-		client:     *route53.New(session.New(), &aws.Config{Region: aws.String(region)}),
+	return &dns{
+		r53:        route53.New(session.New(), &aws.Config{Region: aws.String(region)}),
 		hostedZone: hostedZone,
 	}
 }
 
-// UpdateRecordSets updates records in aws based on the change list.
-func (dns *Route53Client) UpdateRecordSets(changes []*route53.Change) error {
+// GetHostedZone gets the domain for the hosted zone
+func (dns *dns) GetHostedZoneDomain() (string, error) {
+	input := &route53.GetHostedZoneInput{Id: aws.String(dns.hostedZone)}
+	hostedZone, err := dns.r53.GetHostedZone(input)
+	if err != nil {
+		return "", fmt.Errorf("unable to get Hosted Zone Info: %v", err)
+	}
+	return *hostedZone.HostedZone.Name, nil
+}
 
+// UpdateRecordSets updates records in aws based on the change list.
+// Todo add tests
+func (dns *dns) UpdateRecordSets(changes []*route53.Change) error {
 	recordSetsInput := &route53.ChangeResourceRecordSetsInput{
 		HostedZoneId: aws.String(dns.hostedZone),
 		ChangeBatch: &route53.ChangeBatch{
@@ -32,7 +56,7 @@ func (dns *Route53Client) UpdateRecordSets(changes []*route53.Change) error {
 		},
 	}
 
-	_, err := dns.client.ChangeResourceRecordSets(recordSetsInput)
+	_, err := dns.r53.ChangeResourceRecordSets(recordSetsInput)
 
 	if err != nil {
 		return fmt.Errorf("failed to create A record: %v", err)
@@ -42,9 +66,9 @@ func (dns *Route53Client) UpdateRecordSets(changes []*route53.Change) error {
 }
 
 // GetARecords gets a list of A Records from aws.
-func (dns *Route53Client) GetARecords() ([]*route53.ResourceRecordSet, error) {
-
-	recordSetsOutput, err := dns.client.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
+// Todo tests
+func (dns *dns) GetARecords() ([]*route53.ResourceRecordSet, error) {
+	recordSetsOutput, err := dns.r53.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
 		HostedZoneId: aws.String(dns.hostedZone),
 	})
 

--- a/dns/r53/client_test.go
+++ b/dns/r53/client_test.go
@@ -1,0 +1,62 @@
+package r53
+
+import (
+	"testing"
+
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type fake53 struct {
+	mock.Mock
+}
+
+func (m *fake53) GetHostedZone(input *route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error) {
+	args := m.Called(input)
+	err := args.Error(1)
+	if err != nil {
+		return nil, err
+	}
+	return args.Get(0).(*route53.GetHostedZoneOutput), err
+}
+
+func (m *fake53) ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+	panic("not implemented")
+}
+
+func (m *fake53) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+	panic("not implemented")
+}
+
+func TestGetHostedZoneDomain(t *testing.T) {
+	id := "james-zone"
+	zoneDomain := "james.com"
+	dns := New("fake", id).(*dns)
+	fake53 := new(fake53)
+	dns.r53 = fake53
+	fake53.On("GetHostedZone", &route53.GetHostedZoneInput{Id: aws.String(id)}).Return(&route53.GetHostedZoneOutput{
+		HostedZone: &route53.HostedZone{
+			Name: aws.String(zoneDomain),
+		},
+	}, nil)
+
+	hz, err := dns.GetHostedZoneDomain()
+
+	assert.NoError(t, err)
+	assert.Equal(t, zoneDomain, hz)
+}
+
+func TestGetHostedZoneDomainError(t *testing.T) {
+	dns := New("fake", "fake").(*dns)
+	fake53 := new(fake53)
+	dns.r53 = fake53
+	fake53.On("GetHostedZone", mock.Anything).Return(nil, errors.New("james says no"))
+
+	_, err := dns.GetHostedZoneDomain()
+
+	assert.EqualError(t, err, "unable to get Hosted Zone Info: james says no")
+}

--- a/invalid-host-ingress.yml
+++ b/invalid-host-ingress.yml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: verification-app-invalid
+  annotations:
+    sky.uk/frontend-elb-scheme: internal
+spec:
+  rules:
+  - host: verification-app.google.com
+    http:
+      paths:
+      - backend:
+          serviceName: verification-app
+          servicePort: 8080
+        path: /commerce/verification-app/
+status:
+  loadBalancer: {}


### PR DESCRIPTION
This also starts to add tests for the R53 Client.

The logs are a little verbose atm I'll cut them down before I finish working in this area.