### PR TITLE
Fix feed-dns healthy metric name

### DIFF
--- a/cmd/feed-dns/main.go
+++ b/cmd/feed-dns/main.go
@@ -87,7 +87,7 @@ func main() {
 		Updaters:         []controller.Updater{dnsUpdater},
 	})
 
-	cmd.AddHealthMetrics(controller, metrics.PrometheusIngressSubsystem)
+	cmd.AddHealthMetrics(controller, metrics.PrometheusDNSSubsystem)
 	cmd.AddHealthPort(controller, healthPort)
 	cmd.AddSignalHandler(controller)
 


### PR DESCRIPTION
Was feed_ingress_unhealthy_time, this changes it to
feed_dns_unhealthy_time.