### PR TITLE
Don't send duplicate route53 records

### DIFF
--- a/dns/dns_metrics.go
+++ b/dns/dns_metrics.go
@@ -9,7 +9,7 @@ import (
 
 var once sync.Once
 var recordsGauge prometheus.Gauge
-var updateCount, failedCount, invalidIngressCount prometheus.Counter
+var updateCount, failedCount, skippedCount prometheus.Counter
 
 func initMetrics() {
 	once.Do(func() {
@@ -18,7 +18,7 @@ func initMetrics() {
 				Namespace:   metrics.PrometheusNamespace,
 				Subsystem:   metrics.PrometheusDNSSubsystem,
 				Name:        "route53_records",
-				Help:        "The current number of records",
+				Help:        "The current number of records.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Gauge)
 
@@ -27,7 +27,7 @@ func initMetrics() {
 				Namespace:   metrics.PrometheusNamespace,
 				Subsystem:   metrics.PrometheusDNSSubsystem,
 				Name:        "route53_updates",
-				Help:        "The number of record updates to Route53",
+				Help:        "The number of record updates to Route53.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Counter)
 
@@ -36,16 +36,17 @@ func initMetrics() {
 				Namespace:   metrics.PrometheusNamespace,
 				Subsystem:   metrics.PrometheusDNSSubsystem,
 				Name:        "route53_failures",
-				Help:        "The number of failed updates to route53",
+				Help:        "The number of failed updates to route53.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Counter)
 
-		invalidIngressCount = prometheus.MustRegisterOrGet(prometheus.NewCounter(
+		skippedCount = prometheus.MustRegisterOrGet(prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Namespace:   metrics.PrometheusNamespace,
-				Subsystem:   metrics.PrometheusDNSSubsystem,
-				Name:        "invalid_ingress_entries",
-				Help:        "The number of invalid ingress entries",
+				Namespace: metrics.PrometheusNamespace,
+				Subsystem: metrics.PrometheusDNSSubsystem,
+				Name:      "skipped_ingress_entries",
+				Help: "The number of ingress entries skipped by feed-dns, such as being outside of the" +
+					" Route53 hosted zone.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Counter)
 

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -32,7 +32,7 @@ func init() {
 const (
 	port          = 9090
 	fakeNginx     = "./fake_nginx.sh"
-	smallWaitTime = time.Millisecond * 10
+	smallWaitTime = time.Millisecond * 20
 )
 
 type mockSignaller struct {


### PR DESCRIPTION
This was failing when it his the aws api.

I also broke up calculateChanges into several smaller methods, to better
understand what the code is doing.

I also changed "invalid_entries" to "skipped_entries", since we'll
likely have a few things outside of the hosted zone (such as jenkins).
This makes it more explicit that such entries aren't invalid, just
skipped by the dns controller since they are outside of its hosted zone.