### PR TITLE
Add nginx configuration for server_names_hash_*

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -17,56 +17,60 @@ import (
 )
 
 var (
-	debug                        bool
-	apiserverURL                 string
-	caCertFile                   string
-	tokenFile                    string
-	clientCertFile               string
-	clientKeyFile                string
-	ingressPort                  int
-	ingressAllow                 string
-	ingressHealthPort            int
-	healthPort                   int
-	nginxBinary                  string
-	nginxWorkDir                 string
-	nginxWorkerProcesses         int
-	nginxWorkerConnections       int
-	nginxKeepAliveSeconds        int
-	nginxBackendKeepalives       int
-	nginxBackendKeepaliveSeconds int
-	nginxLogLevel                string
-	nginxTrustedFrontends        string
-	elbLabelValue                string
-	elbRegion                    string
-	elbExpectedNumber            int
-	pushgatewayURL               string
-	pushgatewayIntervalSeconds   int
-	pushgatewayLabels            cmd.KeyValues
+	debug                          bool
+	apiserverURL                   string
+	caCertFile                     string
+	tokenFile                      string
+	clientCertFile                 string
+	clientKeyFile                  string
+	ingressPort                    int
+	ingressAllow                   string
+	ingressHealthPort              int
+	healthPort                     int
+	nginxBinary                    string
+	nginxWorkDir                   string
+	nginxWorkerProcesses           int
+	nginxWorkerConnections         int
+	nginxKeepAliveSeconds          int
+	nginxBackendKeepalives         int
+	nginxBackendKeepaliveSeconds   int
+	nginxLogLevel                  string
+	nginxTrustedFrontends          string
+	nginxServerNamesHashBucketSize int
+	nginxServerNamesHashMaxSize    int
+	elbLabelValue                  string
+	elbRegion                      string
+	elbExpectedNumber              int
+	pushgatewayURL                 string
+	pushgatewayIntervalSeconds     int
+	pushgatewayLabels              cmd.KeyValues
 )
 
 func init() {
 	const (
-		defaultAPIServer                    = "https://kubernetes:443"
-		defaultCaCertFile                   = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-		defaultTokenFile                    = ""
-		defaultClientCertFile               = ""
-		defaultClientKeyFile                = ""
-		defaultIngressPort                  = 8080
-		defaultIngressAllow                 = ""
-		defaultIngressHealthPort            = 8081
-		defaultHealthPort                   = 12082
-		defaultNginxBinary                  = "/usr/sbin/nginx"
-		defaultNginxWorkingDir              = "/nginx"
-		defaultNginxWorkers                 = 1
-		defaultNginxWorkerConnections       = 1024
-		defaultNginxKeepAliveSeconds        = 60
-		defaultNginxBackendKeepalives       = 512
-		defaultNginxBackendKeepaliveSeconds = 60
-		defaultNginxLogLevel                = "info"
-		defaultElbLabelValue                = ""
-		defaultElbRegion                    = "eu-west-1"
-		defaultElbExpectedNumber            = 0
-		defaultPushgatewayIntervalSeconds   = 60
+		defaultAPIServer                      = "https://kubernetes:443"
+		defaultCaCertFile                     = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+		defaultTokenFile                      = ""
+		defaultClientCertFile                 = ""
+		defaultClientKeyFile                  = ""
+		defaultIngressPort                    = 8080
+		defaultIngressAllow                   = ""
+		defaultIngressHealthPort              = 8081
+		defaultHealthPort                     = 12082
+		defaultNginxBinary                    = "/usr/sbin/nginx"
+		defaultNginxWorkingDir                = "/nginx"
+		defaultNginxWorkers                   = 1
+		defaultNginxWorkerConnections         = 1024
+		defaultNginxKeepAliveSeconds          = 60
+		defaultNginxBackendKeepalives         = 512
+		defaultNginxBackendKeepaliveSeconds   = 60
+		defaultNginxLogLevel                  = "info"
+		defaultNginxServerNamesHashBucketSize = 128
+		defaultNginxServerNamesHashMaxSize    = 512
+		defaultElbLabelValue                  = ""
+		defaultElbRegion                      = "eu-west-1"
+		defaultElbExpectedNumber              = 0
+		defaultPushgatewayIntervalSeconds     = 60
 	)
 
 	flag.BoolVar(&debug, "debug", false,
@@ -109,6 +113,12 @@ func init() {
 			"times to prevent stale connections.")
 	flag.StringVar(&nginxLogLevel, "nginx-loglevel", defaultNginxLogLevel,
 		"Log level for nginx. See http://nginx.org/en/docs/ngx_core_module.html#error_log for levels.")
+	flag.IntVar(&nginxServerNamesHashBucketSize, "nginx-server-names-hash-bucket-size", defaultNginxServerNamesHashBucketSize,
+		"Sets the bucket size for the server names hash tables.The details of setting up hash tables are provided "+
+			"in a separate document. http://nginx.org/en/docs/hash.html")
+	flag.IntVar(&nginxServerNamesHashMaxSize, "nginx-server-names-hash-max-size", defaultNginxServerNamesHashMaxSize,
+		"Sets the maximum size of the server names hash tables. The details of setting up hash tables are provided "+
+			"in a separate document. http://nginx.org/en/docs/hash.html")
 	flag.StringVar(&nginxTrustedFrontends, "nginx-trusted-frontends", "",
 		"Comma separated list of CIDRs to trust when determining the client's real IP from the "+
 			"X-Forwarded-For header. The client IP is used for allowing or denying ingress access. "+
@@ -164,16 +174,18 @@ func createIngressUpdaters() []controller.Updater {
 		trustedFrontends = strings.Split(nginxTrustedFrontends, ",")
 	}
 	proxy := nginx.New(nginx.Conf{
-		BinaryLocation:          nginxBinary,
-		IngressPort:             ingressPort,
-		WorkingDir:              nginxWorkDir,
-		WorkerProcesses:         nginxWorkerProcesses,
-		WorkerConnections:       nginxWorkerConnections,
-		KeepaliveSeconds:        nginxKeepAliveSeconds,
-		BackendKeepalives:       nginxBackendKeepalives,
-		BackendKeepaliveSeconds: nginxBackendKeepaliveSeconds,
-		HealthPort:              ingressHealthPort,
-		TrustedFrontends:        trustedFrontends,
+		BinaryLocation:            nginxBinary,
+		IngressPort:               ingressPort,
+		WorkingDir:                nginxWorkDir,
+		WorkerProcesses:           nginxWorkerProcesses,
+		WorkerConnections:         nginxWorkerConnections,
+		KeepaliveSeconds:          nginxKeepAliveSeconds,
+		BackendKeepalives:         nginxBackendKeepalives,
+		BackendKeepaliveSeconds:   nginxBackendKeepaliveSeconds,
+		ServerNamesHashBucketSize: nginxServerNamesHashBucketSize,
+		ServerNamesHashMaxSize:    nginxServerNamesHashMaxSize,
+		HealthPort:                ingressHealthPort,
+		TrustedFrontends:          trustedFrontends,
 	})
 	return []controller.Updater{frontend, proxy}
 }

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -114,7 +114,7 @@ func init() {
 	flag.StringVar(&nginxLogLevel, "nginx-loglevel", defaultNginxLogLevel,
 		"Log level for nginx. See http://nginx.org/en/docs/ngx_core_module.html#error_log for levels.")
 	flag.IntVar(&nginxServerNamesHashBucketSize, "nginx-server-names-hash-bucket-size", defaultNginxServerNamesHashBucketSize,
-		"Sets the bucket size for the server names hash tables.The details of setting up hash tables are provided "+
+		"Sets the bucket size for the server names hash tables. The details of setting up hash tables are provided "+
 			"in a separate document. http://nginx.org/en/docs/hash.html")
 	flag.IntVar(&nginxServerNamesHashMaxSize, "nginx-server-names-hash-max-size", defaultNginxServerNamesHashMaxSize,
 		"Sets the maximum size of the server names hash tables. The details of setting up hash tables are provided "+

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -27,17 +27,19 @@ const (
 
 // Conf configuration for nginx
 type Conf struct {
-	BinaryLocation          string
-	WorkingDir              string
-	WorkerProcesses         int
-	WorkerConnections       int
-	KeepaliveSeconds        int
-	BackendKeepalives       int
-	BackendKeepaliveSeconds int
-	HealthPort              int
-	TrustedFrontends        []string
-	IngressPort             int
-	LogLevel                string
+	BinaryLocation            string
+	WorkingDir                string
+	WorkerProcesses           int
+	WorkerConnections         int
+	KeepaliveSeconds          int
+	BackendKeepalives         int
+	BackendKeepaliveSeconds   int
+	ServerNamesHashBucketSize int
+	ServerNamesHashMaxSize    int
+	HealthPort                int
+	TrustedFrontends          []string
+	IngressPort               int
+	LogLevel                  string
 }
 
 // Signaller interface around signalling the loadbalancer process

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -18,6 +18,12 @@ events {
 http {
     default_type text/html;
 
+    # If a large number of server names are defined, or unusually long server names are defined,
+    # tuning the server_names_hash_max_size and server_names_hash_bucket_size directives at the http
+    # level may become necessary.
+    server_names_hash_bucket_size {{ .ServerNamesHashBucketSize }};
+    server_names_hash_max_size {{ .ServerNamesHashMaxSize }};
+
     # Keep alive time for client connections. Don't limit by number of requests.
     keepalive_timeout {{ .KeepaliveSeconds }}s;
     keepalive_requests 2147483647;

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -21,8 +21,8 @@ http {
     # If a large number of server names are defined, or unusually long server names are defined,
     # tuning the server_names_hash_max_size and server_names_hash_bucket_size directives at the http
     # level may become necessary.
-    server_names_hash_bucket_size {{ .ServerNamesHashBucketSize }};
-    server_names_hash_max_size {{ .ServerNamesHashMaxSize }};
+    {{ if .ServerNamesHashBucketSize }}server_names_hash_bucket_size {{ .ServerNamesHashBucketSize }};{{ end }}
+    {{ if .ServerNamesHashMaxSize }}server_names_hash_max_size {{ .ServerNamesHashMaxSize }};{{ end }}
 
     # Keep alive time for client connections. Don't limit by number of requests.
     keepalive_timeout {{ .KeepaliveSeconds }}s;

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -51,14 +51,12 @@ func (m *mockSignaller) sighup(p *os.Process) error {
 
 func newConf(tmpDir string, binary string) Conf {
 	return Conf{
-		WorkingDir:                tmpDir,
-		BinaryLocation:            binary,
-		IngressPort:               port,
-		WorkerProcesses:           1,
-		BackendKeepalives:         1024,
-		BackendKeepaliveSeconds:   58,
-		ServerNamesHashBucketSize: 54,
-		ServerNamesHashMaxSize:    128,
+		WorkingDir:              tmpDir,
+		BinaryLocation:          binary,
+		IngressPort:             port,
+		WorkerProcesses:         1,
+		BackendKeepalives:       1024,
+		BackendKeepaliveSeconds: 58,
 	}
 }
 
@@ -214,12 +212,6 @@ func TestTrustedFrontendsSetsUpClientIPCorrectly(t *testing.T) {
     real_ip_header X-Forwarded-For;
     real_ip_recursive on;`,
 		},
-		{
-			"blash",
-			newConf(tmpDir, fakeNginx),
-			`    server_names_hash_bucket_size 54;
-    server_names_hash_max_size 128;`,
-		},
 	}
 
 	for _, test := range tests {
@@ -236,6 +228,50 @@ func TestTrustedFrontendsSetsUpClientIPCorrectly(t *testing.T) {
 		assert.Contains(configContents, test.expectedOutput, test.name)
 
 	}
+}
+
+func TestServerNamesHashSettingsSetCorrectly(t *testing.T) {
+	assert := assert.New(t)
+	tmpDir := setupWorkDir(t)
+	defer os.Remove(tmpDir)
+
+	conf := newConf(tmpDir, fakeNginx)
+	conf.ServerNamesHashMaxSize = 128
+	conf.ServerNamesHashBucketSize = 58
+
+	lb, _ := newLbWithConf(conf)
+
+	assert.NoError(lb.Start())
+	err := lb.Update(controller.IngressUpdate{})
+	assert.NoError(err)
+
+	config, err := ioutil.ReadFile(tmpDir + "/nginx.conf")
+	assert.NoError(err)
+	configContents := string(config)
+
+	assert.Contains(configContents, "    server_names_hash_max_size 128;", "server_names_hash_max_size is set")
+	assert.Contains(configContents, "    server_names_hash_bucket_size 58;", "server_names_hash_max_size is set")
+}
+
+func TestServerNamesHashSettingsNotSetByDefault(t *testing.T) {
+	assert := assert.New(t)
+	tmpDir := setupWorkDir(t)
+	defer os.Remove(tmpDir)
+
+	conf := newConf(tmpDir, fakeNginx)
+
+	lb, _ := newLbWithConf(conf)
+
+	assert.NoError(lb.Start())
+	err := lb.Update(controller.IngressUpdate{})
+	assert.NoError(err)
+
+	config, err := ioutil.ReadFile(tmpDir + "/nginx.conf")
+	assert.NoError(err)
+	configContents := string(config)
+
+	assert.NotContains(configContents, "    server_names_hash_max_size", "server_names_hash_max_size is set")
+	assert.NotContains(configContents, "    server_names_hash_bucket_size", "server_names_hash_max_size is set")
 }
 
 func TestNginxConfigUpdates(t *testing.T) {

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -51,12 +51,14 @@ func (m *mockSignaller) sighup(p *os.Process) error {
 
 func newConf(tmpDir string, binary string) Conf {
 	return Conf{
-		WorkingDir:              tmpDir,
-		BinaryLocation:          binary,
-		IngressPort:             port,
-		WorkerProcesses:         1,
-		BackendKeepalives:       1024,
-		BackendKeepaliveSeconds: 58,
+		WorkingDir:                tmpDir,
+		BinaryLocation:            binary,
+		IngressPort:               port,
+		WorkerProcesses:           1,
+		BackendKeepalives:         1024,
+		BackendKeepaliveSeconds:   58,
+		ServerNamesHashBucketSize: 54,
+		ServerNamesHashMaxSize:    128,
 	}
 }
 
@@ -211,6 +213,12 @@ func TestTrustedFrontendsSetsUpClientIPCorrectly(t *testing.T) {
 
     real_ip_header X-Forwarded-For;
     real_ip_recursive on;`,
+		},
+		{
+			"blash",
+			newConf(tmpDir, fakeNginx),
+			`    server_names_hash_bucket_size 54;
+    server_names_hash_max_size 128;`,
 		},
 	}
 


### PR DESCRIPTION
Allows configuration of `server_names_hash_bucket_size` and
`server_names_hash_max_size`

Closes https://github.com/sky-uk/umc-core/issues/1191