### PR TITLE
Add apt-get clean before doing an update.

### DIFF
--- a/Dockerfile_dns
+++ b/Dockerfile_dns
@@ -1,9 +1,11 @@
 FROM debian:jessie
 
-RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confnew" \
+RUN apt-get clean \
+    && apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confnew" \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*  # 2016-06-01
 
-RUN apt-get update \
+RUN apt-get clean \
+	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 						ca-certificates \
 						curl \

--- a/Dockerfile_ingress
+++ b/Dockerfile_ingress
@@ -1,12 +1,14 @@
 FROM debian:jessie
 
-RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confnew" \
+RUN apt-get clean \
+    && apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confnew" \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*  # 2016-06-01
 
 ENV NGINX_VERSION 1.10.1-1~jessie
 
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 \
 	&& echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list \
+	&& apt-get clean \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 						ca-certificates \


### PR DESCRIPTION
To resolve problems caused by apt's local cache not matching upstream