### PR TITLE
Move proxy settings into http top level

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -48,10 +48,41 @@ http {
     uwsgi_temp_path        {{ .WorkingDir }}/tmp_uwsgi 1 2;
     scgi_temp_path         {{ .WorkingDir }}/tmp_scgi 1 2;
 
+    # Configure proxying
+    # Enable keepalive to backend.
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+
+    # Add headers for proxy information.
+    map $http_x_forwarded_proto $frontend_scheme {
+        default $http_x_forwarded_proto;
+        '' $scheme;
+    }
+    map $http_x_forwarded_port $frontend_port {
+        default $http_x_forwarded_port;
+        '' $server_port;
+    }
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $host:$frontend_port;
+    proxy_set_header X-Forwarded-Proto $frontend_scheme;
+    proxy_set_header X-Original-URI $request_uri;
+    proxy_set_header X-Real-IP $remote_addr;
+
+    # Timeout faster than the default 60s on initial connect.
+    proxy_connect_timeout 10s;
+
+    # Close proxy connections after backend keepalive time.
+    proxy_read_timeout {{ .BackendKeepaliveSeconds }}s;
+    proxy_send_timeout {{ .BackendKeepaliveSeconds }}s;
+
+    # Disable buffering, as we'll be interacting with ELBs with http listeners, which we assume will
+    # quickly consume and generate responses and requests.
+    # This should be enabled if nginx will directly serve traffic externally to unknown clients.
+    proxy_buffering off;
+
     # Configure ingresses
     {{ $port := .IngressPort }}
     {{ $keepalive := .BackendKeepalives }}
-    {{ $keepaliveSeconds := .BackendKeepaliveSeconds }}
     {{ range $entry := .Entries }}
     # Start entry
     #{{ $entry.Name }}
@@ -77,27 +108,6 @@ http {
             {{ range $location.Allow }}allow {{ . }};
             {{ end }}
             deny all;
-
-            # Enable keepalive to backend.
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-
-            # Add X-Forwarded-For and X-Original-URI for proxy information.
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Original-URI $request_uri;
-
-            # Timeout faster than the default 60s on initial connect.
-            proxy_connect_timeout 10s;
-
-            # Close proxy connections after backend keepalive time.
-            proxy_read_timeout {{ $keepaliveSeconds }}s;
-            proxy_send_timeout {{ $keepaliveSeconds }}s;
-
-            # Disable buffering, as we'll be interacting with ELBs with http listeners, which we assume will
-            # quickly consume and generate responses and requests.
-            # This should be enabled if nginx will directly serve traffic externally to unknown clients.
-            proxy_buffering off;
-            proxy_request_buffering off;
         }
         {{- end }}
     }

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -337,26 +337,6 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"            allow 10.82.0.0/16;\n" +
 					"            \n" +
 					"            deny all;\n" +
-					"\n" +
-					"            # Enable keepalive to backend.\n" +
-					"            proxy_http_version 1.1;\n" +
-					"            proxy_set_header Connection \"\";\n" +
-					"\n" +
-					"            # Add X-Forwarded-For and X-Original-URI for proxy information.\n" +
-					"            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n" +
-					"            proxy_set_header X-Original-URI $request_uri;\n" +
-					"\n            # Timeout faster than the default 60s on initial connect.\n" +
-					"            proxy_connect_timeout 10s;\n" +
-					"\n" +
-					"            # Close proxy connections after backend keepalive time.\n" +
-					"            proxy_read_timeout 58s;\n" +
-					"            proxy_send_timeout 58s;\n" +
-					"\n" +
-					"            # Disable buffering, as we'll be interacting with ELBs with http listeners, which we assume will\n" +
-					"            # quickly consume and generate responses and requests.\n" +
-					"            # This should be enabled if nginx will directly serve traffic externally to unknown clients.\n" +
-					"            proxy_buffering off;\n" +
-					"            proxy_request_buffering off;\n" +
 					"        }\n" +
 					"\n" +
 					"        location /anotherpath/ {\n" +
@@ -370,26 +350,6 @@ func TestNginxConfigUpdates(t *testing.T) {
 					"            allow 10.86.0.0/16;\n" +
 					"            \n" +
 					"            deny all;\n" +
-					"\n" +
-					"            # Enable keepalive to backend.\n" +
-					"            proxy_http_version 1.1;\n" +
-					"            proxy_set_header Connection \"\";\n" +
-					"\n" +
-					"            # Add X-Forwarded-For and X-Original-URI for proxy information.\n" +
-					"            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n" +
-					"            proxy_set_header X-Original-URI $request_uri;\n" +
-					"\n            # Timeout faster than the default 60s on initial connect.\n" +
-					"            proxy_connect_timeout 10s;\n" +
-					"\n" +
-					"            # Close proxy connections after backend keepalive time.\n" +
-					"            proxy_read_timeout 58s;\n" +
-					"            proxy_send_timeout 58s;\n" +
-					"\n" +
-					"            # Disable buffering, as we'll be interacting with ELBs with http listeners, which we assume will\n" +
-					"            # quickly consume and generate responses and requests.\n" +
-					"            # This should be enabled if nginx will directly serve traffic externally to unknown clients.\n" +
-					"            proxy_buffering off;\n" +
-					"            proxy_request_buffering off;\n" +
 					"        }\n" +
 					"    }\n",
 			},


### PR DESCRIPTION
To avoid massive duplication in every single Location.

Also add missing X-Forwarded-* as used by jetty, tomcat, and other
connectors.