### PR TITLE
Support PROXY protocol

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -39,6 +39,7 @@ var (
 	nginxTrustedFrontends          string
 	nginxServerNamesHashBucketSize int
 	nginxServerNamesHashMaxSize    int
+	nginxProxyProtocol             bool
 	elbLabelValue                  string
 	elbRegion                      string
 	elbExpectedNumber              int
@@ -69,6 +70,7 @@ func init() {
 		defaultNginxLogLevel                  = "warn"
 		defaultNginxServerNamesHashBucketSize = -1
 		defaultNginxServerNamesHashMaxSize    = -1
+		defaultNginxProxyProtocol             = false
 		defaultElbLabelValue                  = ""
 		defaultElbRegion                      = "eu-west-1"
 		defaultElbExpectedNumber              = 0
@@ -131,9 +133,11 @@ func init() {
 			"config from the nginx conf file. The details of setting up hash tables are provided "+
 			"in a separate document. http://nginx.org/en/docs/hash.html")
 	flag.StringVar(&nginxTrustedFrontends, "nginx-trusted-frontends", "",
-		"Comma separated list of CIDRs to trust when determining the client's real IP from the "+
-			"X-Forwarded-For header. The client IP is used for allowing or denying ingress access. "+
+		"Comma separated list of CIDRs to trust when determining the client's real IP from "+
+			"frontends. The client IP is used for allowing or denying ingress access. "+
 			"This will typically be the ELB subnet.")
+	flag.BoolVar(&nginxProxyProtocol, "nginx-proxy-protocol", defaultNginxProxyProtocol,
+		"Enable PROXY protocol for nginx listeners.")
 	flag.StringVar(&elbLabelValue, "elb-label-value", defaultElbLabelValue,
 		"Attach to ELBs tagged with "+elb.ElbTag+"=value. Leave empty to not attach.")
 	flag.IntVar(&elbExpectedNumber, "elb-expected-number", defaultElbExpectedNumber,
@@ -199,6 +203,7 @@ func createIngressUpdaters() []controller.Updater {
 		ServerNamesHashMaxSize:    nginxServerNamesHashMaxSize,
 		HealthPort:                ingressHealthPort,
 		TrustedFrontends:          trustedFrontends,
+		ProxyProtocol:             nginxProxyProtocol,
 	})
 	return []controller.Updater{frontend, proxy}
 }

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -41,6 +41,7 @@ type Conf struct {
 	TrustedFrontends          []string
 	IngressPort               int
 	LogLevel                  string
+	ProxyProtocol             bool
 }
 
 // Signaller interface around signalling the loadbalancer process

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -34,10 +34,10 @@ http {
     # Disable nginx version leakage to external clients.
     server_tokens off;
 
-    # Obtain client IP from frontend's X-Forward-For header
+    # Obtain client IP from frontend
 {{ range .TrustedFrontends }}    set_real_ip_from {{ . }};
 {{ end }}
-    real_ip_header X-Forwarded-For;
+    real_ip_header {{ if .ProxyProtocol }}proxy_protocol{{ else }}X-Forwarded-For{{ end }};
     real_ip_recursive on;
 
     # Put all data into the working directory.
@@ -77,8 +77,9 @@ http {
     proxy_buffering off;
 
     # Configure ingresses
-    {{ $port := .IngressPort }}
-    {{ $keepalive := .BackendKeepalives }}
+    {{- $port := .IngressPort }}
+    {{- $keepalive := .BackendKeepalives }}
+    {{- $proxyprotocol := .ProxyProtocol }}
     {{ range $entry := .Entries }}
     # Start entry
     #{{ $entry.Name }}
@@ -89,7 +90,7 @@ http {
     }
 {{ end }}
     server {
-        listen {{ $port }};
+        listen {{ $port }}{{ if $proxyprotocol }} proxy_protocol{{ end }};
         server_name {{ $entry.ServerName }};
         {{- range $location := $entry.Locations }}
 


### PR DESCRIPTION
Add `-nginx-proxy-protocol` which turns on TCP PROXY protocol for the
nginx listeners.