### PR TITLE
Disable payload limits

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -92,6 +92,10 @@ http {
     server {
         listen {{ $port }}{{ if $proxyprotocol }} proxy_protocol{{ end }};
         server_name {{ $entry.ServerName }};
+
+        # disable any limits to avoid HTTP 413 for large uploads
+        client_max_body_size 0; 
+
         {{- range $location := $entry.Locations }}
 
         location {{ if $location.Path }}{{ $location.Path }}{{ end }} {

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -312,6 +312,9 @@ func TestNginxIngressEntries(t *testing.T) {
 					"        listen 9090;\n" +
 					"        server_name chris.com;\n" +
 					"\n" +
+					"        # disable any limits to avoid HTTP 413 for large uploads\n" +
+					"        client_max_body_size 0;\n" +
+					"\n" +
 					"        location /path/ {\n" +
 					"            # Strip location path when proxying.\n" +
 					"            # Beware this can cause issues with url encoded characters.\n" +


### PR DESCRIPTION
This is required for any request that uploads a file via ingress e.g. a docker
registry