### PR TITLE
Pass Host header to proxied server

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -67,6 +67,7 @@ http {
     proxy_set_header X-Forwarded-Proto $frontend_scheme;
     proxy_set_header X-Original-URI $request_uri;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
 
     # Timeout faster than the default 60s on initial connect.
     proxy_connect_timeout 10s;


### PR DESCRIPTION
So proxied servers that do not honour the `X-Forwarded-Host` header, can use the `Host` request header when sending 302 redirects.

Fixes sky-uk/umc-core#1739