### PR TITLE
Add vhost_traffic_status module, connect timeout

### DIFF
--- a/Dockerfile_ingress
+++ b/Dockerfile_ingress
@@ -1,29 +1,27 @@
 FROM phusion/baseimage:0.9.19
 
-ENV NGINX_VERSION 1.10.1-1~xenial
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install --no-install-suggests --no-install-recommends -y \
+        curl \
+        dnsutils \
+        vim-tiny \
+        lsof \
+    && apt-get clean -y \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN curl http://nginx.org/keys/nginx_signing.key > /tmp/nginx_signing.key \
-    && apt-key add /tmp/nginx_signing.key \
-    && rm -f /tmp/nginx_signing.key \
-	&& echo "deb http://nginx.org/packages/ubuntu/ xenial nginx" >> /etc/apt/sources.list \
-	&& apt-get upgrade -y -o Dpkg::Options::="--force-confnew" \
-	&& apt-get update \
-	&& apt-get install --no-install-recommends --no-install-suggests -y \
-						ca-certificates \
-						nginx=${NGINX_VERSION} \
-						gettext-base \
-						curl \
-						dnsutils \
-						vim-tiny \
-						lsof \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* # 2016-07-13
+ENV NGINX_VERSION 1.10.1
+ENV NGINX_SHA256 1fd35846566485e03c0e318989561c135c598323ff349c503a6c14826487a801
+ENV VTS_VERSION 0.1.10
+ENV VTS_SHA256 c6f3733e9ff84bfcdc6bfb07e1baf59e72c4e272f06964dd0ed3a1bdc93fa0ca
 
-WORKDIR /
+COPY build-nginx.sh /tmp
+RUN /bin/bash /tmp/build-nginx.sh
+
 COPY feed-ingress /
-
-RUN mkdir /nginx
 COPY nginx.tmpl /nginx/
-RUN chown -R nginx:nginx /nginx
+RUN chown nginx:nginx /nginx/nginx.tmpl
 
 ENTRYPOINT ["/sbin/my_init", "--quiet", "--", "/sbin/setuser", "nginx", \
     "/feed-ingress", "-nginx-workdir", "/nginx"]

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ copy : build
 	  set -e; \
 	  build_dir="build/$$build"; \
 	  mkdir -p $$build_dir; \
+	  cp build-nginx.sh $$build_dir; \
 	  cp Dockerfile_$$build $${build_dir}/Dockerfile; \
 	  cp $(GOPATH)/bin/feed-$$build $$build_dir; \
 	done

--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -ex
+
+useradd -s /sbin/nologin nginx
+mkdir -p /nginx /var/cache/nginx
+chown -R nginx:nginx /nginx /var/cache/nginx
+
+apt-get update
+apt-get install --no-install-suggests --no-install-recommends -y \
+    build-essential \
+    libc6 libc6-dev \
+    libpcre3 libpcre3-dev libpcrecpp0v5 \
+    zlib1g zlib1g-dev \
+    libaio1 libaio-dev
+
+echo "--- Downloading nginx and modules"
+mkdir /tmp/nginx
+cd /tmp/nginx
+curl -O http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
+curl -JLO https://github.com/vozlt/nginx-module-vts/archive/v${VTS_VERSION}.tar.gz
+
+nginx_tarball="nginx-${NGINX_VERSION}.tar.gz"
+vts_tarball="nginx-module-vts-${VTS_VERSION}.tar.gz"
+
+touch hashes
+echo "${NGINX_SHA256} ${nginx_tarball}" >> hashes
+echo "${VTS_SHA256} ${vts_tarball}" >> hashes
+if ! sha256sum -c hashes; then
+    echo "sha256 hashes do not match downloaded files"
+    exit 1
+fi
+
+tar xzf nginx-${NGINX_VERSION}.tar.gz
+tar xzf nginx-module-vts-${VTS_VERSION}.tar.gz
+cd nginx-${NGINX_VERSION}
+
+echo "--- Configuring nginx"
+./configure \
+    --prefix=/nginx \
+    --sbin-path=/usr/sbin/nginx \
+    --conf-path=/nginx/nginx.conf \
+    --error-log-path=/dev/stderr \
+    --http-log-path=/dev/stdout \
+    --pid-path=/var/run/nginx.pid \
+    --lock-path=/var/run/nginx.lock \
+    --http-client-body-temp-path=/var/cache/nginx/client_temp \
+    --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+    --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+    --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+    --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+    --user=nginx \
+    --group=nginx \
+    --with-http_realip_module \
+    --with-http_stub_status_module \
+    --with-threads \
+    --with-file-aio \
+    --with-http_v2_module \
+    --with-ipv6 \
+    --with-debug \
+    --add-module=/tmp/nginx/nginx-module-vts-0.1.10
+
+echo "--- Building nginx"
+make
+make install
+
+echo "--- Cleaning up"
+apt-get purge -y build-essential libc6-dev libpcre3-dev zlib1g-dev libaio-dev gcc-5 cpp-5
+apt-get clean -y
+rm -rf /var/lib/apt/lists/* /tmp/*

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -29,19 +29,20 @@ const (
 
 // Conf configuration for nginx
 type Conf struct {
-	BinaryLocation            string
-	WorkingDir                string
-	WorkerProcesses           int
-	WorkerConnections         int
-	KeepaliveSeconds          int
-	BackendKeepalives         int
-	ServerNamesHashBucketSize int
-	ServerNamesHashMaxSize    int
-	HealthPort                int
-	TrustedFrontends          []string
-	IngressPort               int
-	LogLevel                  string
-	ProxyProtocol             bool
+	BinaryLocation               string
+	WorkingDir                   string
+	WorkerProcesses              int
+	WorkerConnections            int
+	KeepaliveSeconds             int
+	BackendKeepalives            int
+	BackendConnectTimeoutSeconds int
+	ServerNamesHashBucketSize    int
+	ServerNamesHashMaxSize       int
+	HealthPort                   int
+	TrustedFrontends             []string
+	IngressPort                  int
+	LogLevel                     string
+	ProxyProtocol                bool
 }
 
 // Signaller interface around signalling the loadbalancer process
@@ -198,7 +199,7 @@ func (lb *nginxLoadBalancer) periodicallyUpdateMetrics() {
 }
 
 func (lb *nginxLoadBalancer) updateMetrics() {
-	if err := parseAndSetNginxMetrics(lb.HealthPort, "/status"); err != nil {
+	if err := parseAndSetNginxMetrics(lb.HealthPort, "/basic_status"); err != nil {
 		log.Warnf("Unable to update nginx metrics: %v", err)
 		lb.metricsUnhealthy.Set(true)
 	} else {

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -18,9 +18,10 @@ events {
 http {
     default_type text/html;
 
-    # If a large number of server names are defined, or unusually long server names are defined,
-    # tuning the server_names_hash_max_size and server_names_hash_bucket_size directives at the http
-    # level may become necessary.
+    # Track extended virtual host stats.
+    vhost_traffic_status_zone;
+
+    # Server names hash bucket sizes. Set based on nginx log messages.
     {{ if gt .ServerNamesHashBucketSize 0 }}server_names_hash_bucket_size {{ .ServerNamesHashBucketSize }};{{ end }}
     {{ if gt .ServerNamesHashMaxSize 0 }}server_names_hash_max_size {{ .ServerNamesHashMaxSize }};{{ end }}
 
@@ -40,18 +41,15 @@ http {
     real_ip_header {{ if .ProxyProtocol }}proxy_protocol{{ else }}X-Forwarded-For{{ end }};
     real_ip_recursive on;
 
-    # Put all data into the working directory.
+    # Disable access log
     access_log             off;
-    client_body_temp_path  {{ .WorkingDir }}/tmp_client_body 1 2;
-    proxy_temp_path        {{ .WorkingDir }}/tmp_proxy 1 2;
-    fastcgi_temp_path      {{ .WorkingDir }}/tmp_fastcgi 1 2;
-    uwsgi_temp_path        {{ .WorkingDir }}/tmp_uwsgi 1 2;
-    scgi_temp_path         {{ .WorkingDir }}/tmp_scgi 1 2;
 
-    # Configure proxying
     # Enable keepalive to backend.
     proxy_http_version 1.1;
     proxy_set_header Connection "";
+
+    # Mitigate httpoxy vulnerability.
+    proxy_set_header Proxy "";
 
     # Add headers for proxy information.
     map $http_x_forwarded_proto $frontend_scheme {
@@ -69,13 +67,16 @@ http {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $host;
 
-    # Timeout faster than the default 60s on initial connect.
-    proxy_connect_timeout 10s;
+    # Timeout to backend services on initial connect.
+    proxy_connect_timeout {{ .BackendConnectTimeoutSeconds }}s;
 
     # Disable buffering, as we'll be interacting with ELBs with http listeners, which we assume will
     # quickly consume and generate responses and requests.
     # This should be enabled if nginx will directly serve traffic externally to unknown clients.
     proxy_buffering off;
+
+    # Don't mess with redirects.
+    proxy_redirect off;
 
     # Configure ingresses
     {{- $port := .IngressPort }}
@@ -109,6 +110,9 @@ http {
             proxy_pass http://{{ $location.UpstreamID }};
 {{- end }}
 
+            # Set display name for vhost stats.
+            vhost_traffic_status_filter_by_set_key {{ $location.Path }}::$proxy_host $server_name;
+
             # Close proxy connections after backend keepalive time.
             proxy_read_timeout {{ $location.BackendKeepaliveSeconds }}s;
             proxy_send_timeout {{ $location.BackendKeepaliveSeconds }}s;
@@ -139,15 +143,22 @@ http {
     # Status port. This should be firewalled to only allow internal access.
     server {
         listen {{ .HealthPort }} default_server reuseport;
+        vhost_traffic_status off;
 
         location /health {
             access_log off;
             return 200;
         }
 
-        location /status {
+        location /basic_status {
             access_log off;
             stub_status;
+        }
+
+        location /status {
+            access_log off;
+            vhost_traffic_status_display;
+            vhost_traffic_status_display_format html;
         }
 
         location / {


### PR DESCRIPTION
For more detailed monitoring per upstream and virtual host.

This is now on /status, and stub_status is moved to /basic_status.

Also added ability to specify the proxy connect timeout, via
-nginx-backend-connect-timeout-seconds.