### PR TITLE
Toggle access logs via command line argument

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -47,6 +47,8 @@ var (
 	pushgatewayURL                    string
 	pushgatewayIntervalSeconds        int
 	pushgatewayLabels                 cmd.KeyValues
+	accessLog                         bool
+	accessLogDir                      string
 )
 
 func init() {
@@ -77,6 +79,7 @@ func init() {
 		defaultElbRegion                         = "eu-west-1"
 		defaultElbExpectedNumber                 = 0
 		defaultPushgatewayIntervalSeconds        = 60
+		defaultAccessLogDir                      = "/var/log/nginx"
 	)
 
 	flag.BoolVar(&debug, "debug", false,
@@ -156,6 +159,8 @@ func init() {
 		"Interval in seconds for pushing metrics.")
 	flag.Var(&pushgatewayLabels, "pushgateway-label",
 		"A label=value pair to attach to metrics pushed to prometheus. Specify multiple times for multiple labels.")
+	flag.StringVar(&accessLogDir, "access-log-dir", defaultAccessLogDir, "Access logs direcoty.")
+	flag.BoolVar(&accessLog, "access-log", false, "Enable access logs directive.")
 }
 
 func main() {
@@ -210,6 +215,8 @@ func createIngressUpdaters() []controller.Updater {
 		HealthPort:                   ingressHealthPort,
 		TrustedFrontends:             trustedFrontends,
 		ProxyProtocol:                nginxProxyProtocol,
+		AccessLog:                    accessLog,
+		AccessLogDir:                 accessLogDir,
 	})
 	return []controller.Updater{frontend, proxy}
 }

--- a/examples/pod.yml
+++ b/examples/pod.yml
@@ -74,6 +74,10 @@ containers:
   # needs to be greater than 64 to support our very large domain names
   - -nginx-server-names-hash-bucket-size=128
 
+  # access logs are turned on, remove the "-access-log" flag to turn them off
+  - -access-log
+  - -access-log-dir=/var/log/nginx
+
   # controller health determines readiness
   readinessProbe:
     httpGet:
@@ -102,3 +106,11 @@ containers:
      value: http://proxy
    - name: NO_PROXY
      value: ignore
+
+  volumeMounts:
+  - name: nginx-log
+    mountPath: /var/log/nginx
+
+volumes:
+- name: nginx-log
+  emptyDir: {}

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -238,15 +238,6 @@ func (lb *nginxLoadBalancer) Update(entries controller.IngressUpdate) error {
 
 func (lb *nginxLoadBalancer) update(entries controller.IngressUpdate) (bool, error) {
 	log.Debugf("Updating loadbalancer %s", entries)
-
-	if lb.Conf.AccessLog {
-		log.Infof("Access log directive enabled. Log files will be written in: %s", lb.Conf.AccessLogDir)
-		if err := os.MkdirAll(lb.Conf.AccessLogDir, 0755); err != nil {
-			log.Errorf("Could not create access log dir. Error: %v", err)
-			return false, err
-		}
-	}
-
 	updatedConfig, err := lb.createConfig(entries)
 	if err != nil {
 		return false, err

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -43,6 +43,8 @@ type Conf struct {
 	IngressPort                  int
 	LogLevel                     string
 	ProxyProtocol                bool
+	AccessLog                    bool
+	AccessLogDir                 string
 }
 
 // Signaller interface around signalling the loadbalancer process
@@ -236,6 +238,15 @@ func (lb *nginxLoadBalancer) Update(entries controller.IngressUpdate) error {
 
 func (lb *nginxLoadBalancer) update(entries controller.IngressUpdate) (bool, error) {
 	log.Debugf("Updating loadbalancer %s", entries)
+
+	if lb.Conf.AccessLog {
+		log.Infof("Access log directive enabled. Log files will be written in: %s", lb.Conf.AccessLogDir)
+		if err := os.MkdirAll(lb.Conf.AccessLogDir, 0755); err != nil {
+			log.Errorf("Could not create access log dir. Error: %v", err)
+			return false, err
+		}
+	}
+
 	updatedConfig, err := lb.createConfig(entries)
 	if err != nil {
 		return false, err

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -41,8 +41,15 @@ http {
     real_ip_header {{ if .ProxyProtocol }}proxy_protocol{{ else }}X-Forwarded-For{{ end }};
     real_ip_recursive on;
 
-    # Disable access log
-    access_log             off;
+    # Log format tracking timings
+    log_format upstream_time '$remote_addr - $remote_user [$time_local] '
+                             '"$request" $status $body_bytes_sent '
+                             '"$http_referer" "$http_user_agent" '
+                             '"$host" uip="$upstream_addr" ust="$upstream_status" '
+                             'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+
+    # Access logs
+    access_log {{ if .AccessLog }}{{ .AccessLogDir }}/access.log upstream_time buffer=32k flush=1m{{ else }}off{{ end }};
 
     # Enable keepalive to backend.
     proxy_http_version 1.1;

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -42,14 +42,14 @@ http {
     real_ip_recursive on;
 
     # Log format tracking timings
-    log_format upstream_time '$remote_addr - $remote_user [$time_local] '
+    log_format upstream_info '$remote_addr - $remote_user [$time_local] '
                              '"$request" $status $body_bytes_sent '
                              '"$http_referer" "$http_user_agent" '
                              '"$host" uip="$upstream_addr" ust="$upstream_status" '
                              'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
 
     # Access logs
-    access_log {{ if .AccessLog }}{{ .AccessLogDir }}/access.log upstream_time buffer=32k flush=1m{{ else }}off{{ end }};
+    access_log {{ if .AccessLog }}{{ .AccessLogDir }}/access.log upstream_info buffer=32k flush=1m{{ else }}off{{ end }};
 
     # Enable keepalive to backend.
     proxy_http_version 1.1;

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -789,6 +789,26 @@ func TestFailsToUpdateIfConfigurationIsBroken(t *testing.T) {
 	assert.Contains(err.Error(), "./fake_nginx_failing_reload.sh -t")
 }
 
+func TestNginxAccessLogDirIsCreatedWhenAccessLogsEnabled(t *testing.T) {
+	assert := assert.New(t)
+	tmpDir := setupWorkDir(t)
+	defer os.Remove(tmpDir)
+
+	defaultConf := newConf(tmpDir, fakeNginx)
+	enabledAccessLogConf := defaultConf
+	enabledAccessLogConf.AccessLog = true
+	enabledAccessLogConf.AccessLogDir = tmpDir + "/nginx-access-log"
+
+	lb, _ := newLbWithConf(enabledAccessLogConf)
+
+	assert.NoError(lb.Start())
+	err := lb.Update(controller.IngressUpdate{})
+	assert.NoError(err)
+
+	_, statsErr := os.Stat(tmpDir + "/nginx-access-log")
+	assert.NoError(statsErr)
+}
+
 func setupWorkDir(t *testing.T) string {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "ingress_lb_test")
 	assert.NoError(t, err)


### PR DESCRIPTION
- Enable access logs when "access-log" command line arg is provided.
- Access logs will be written by default in /var/log/nginx/access.log. The target directory can be overriden via command line arg "access-log-dir"
- Access logs use a custom format to capture various time values between
  nginx and upstream servers
- Access logs are buffered and flushed every minute unless buffer is full