### PR TITLE
Basic throttling for nginx updates

### DIFF
--- a/controller/updater.go
+++ b/controller/updater.go
@@ -7,6 +7,7 @@ type Updater interface {
 	// Stop the ingress updater. Blocks until the ingress updater stops or an error occurs.
 	Stop() error
 	// Update the ingress updater configuration.
+	// Not thread safe, should only be called by a single go routine
 	Update(IngressUpdate) error
 	// Health returns nil if healthy, otherwise an error. Should be fast to respond, as it
 	// may be called often. Any long running checks should be done separately.

--- a/nginx/blocking_nginx.sh
+++ b/nginx/blocking_nginx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo $0 $@
+if [[ "$1" == "-v" || "$1" == "-t" ]]; then
+    sleep 0.1
+else
+    sleep 2
+fi
+


### PR DESCRIPTION
If many updates came in in a short space of time nginx spawns
many workers processes resulting in OOM kills