### PR TITLE
Synchronously update nginx for the first update

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -207,5 +207,6 @@ func createIngressUpdaters() []controller.Updater {
 	nginxConfig.LogHeaders = logHeaders
 
 	proxy := nginx.New(nginxConfig)
-	return []controller.Updater{frontend, proxy}
+	// update nginx before attaching to front ends
+	return []controller.Updater{proxy, frontend}
 }


### PR DESCRIPTION
Otherwise ingress can be unavailble for up to 30s