### PR TITLE
Add shared scripts for nginx log rotation

### DIFF
--- a/scripts/logrotate.config
+++ b/scripts/logrotate.config
@@ -5,6 +5,7 @@
         missingok
         create 640 nginx nginx
         compress
+        sharedscripts
         postrotate
                 [ ! -f /nginx/nginx.pid ] || kill -USR1 `cat /nginx/nginx.pid`
         endscript


### PR DESCRIPTION
If multiple log files are found e.g. error.log the postrotate will be
executed multiple times witout this