### PR TITLE
Fix ALB flag if it's empty

### DIFF
--- a/util/cmd/csv.go
+++ b/util/cmd/csv.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CommaSeparatedValues represents a slice of strings that were originally separated by ','.
+type CommaSeparatedValues []string
+
+func (c *CommaSeparatedValues) String() string {
+	return fmt.Sprint(*c)
+}
+
+// Set binds a comma separated command line flag value to a KeyValue.
+func (c *CommaSeparatedValues) Set(value string) error {
+	if value != "" {
+		*c = strings.Split(value, ",")
+	}
+	return nil
+}

--- a/util/cmd/csv_test.go
+++ b/util/cmd/csv_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettingCSV(t *testing.T) {
+	assert := assert.New(t)
+
+	csv := CommaSeparatedValues{}
+	csv.Set("first,second,third")
+
+	assert.Equal(CommaSeparatedValues{"first", "second", "third"}, csv)
+}
+
+func TestSettingEmptyCSV(t *testing.T) {
+	assert := assert.New(t)
+
+	csv := CommaSeparatedValues{}
+	csv.Set("")
+
+	assert.Equal(CommaSeparatedValues{}, csv)
+}


### PR DESCRIPTION
This will be needed for the feed-dns change as well which is currently
pending.

Missed the usual problem of "".Split(",") producing {""}.