### PR TITLE
Deregister from ALB target groups gracefully

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -268,7 +268,8 @@ func (c *controller) Stop() error {
 	log.Info("Stopping controller")
 	close(c.doneCh)
 
-	for _, u := range c.updaters {
+	for i := range c.updaters {
+		u := c.updaters[len(c.updaters)-i-1]
 		if err := u.Stop(); err != nil {
 			log.Warnf("Error while stopping %v: %v", u, err)
 		}


### PR DESCRIPTION
- Wait for deregistration delay after sending deregister request, to
ensure connections are drained off in the ALB before stopping nginx.
- Controller stops updaters in reverse order, so ALB is detached before
nginx is stopped.