### PR TITLE
Don't log 404s on error level

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -51,6 +51,9 @@ http {
     # Access logs
     access_log {{ if .AccessLog }}{{ .AccessLogDir }}/access.log upstream_info buffer=32k flush=1m{{ else }}off{{ end }};
 
+    # Disable all logging of 404s - to prevent spam when error log is enabled.
+    log_not_found off;
+
     # Enable keepalive to backend.
     proxy_http_version 1.1;
     proxy_set_header Connection "";


### PR DESCRIPTION
To prevent spam when using an error log level of 'error'.