### PR TITLE
Log nginx diff at info level.

### DIFF
--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -297,7 +297,7 @@ func (n *nginxUpdater) diffAndUpdate(existing, updated []byte) (bool, error) {
 		return false, nil
 	}
 
-	log.Debugf("Updating nginx config: %s", string(diffOutput))
+	log.Infof("Updating nginx config: %s", string(diffOutput))
 	_, err = writeFile(n.nginxConfFile(), updated)
 
 	if err != nil {


### PR DESCRIPTION
There have recently been many problems around getting 502's and 504's partly
caused by nginx reloading. Nginx has also been noticed to reload far more
frequently than expected (10-20 times an hour) and it is very difficult to
investigate the cause of the reload without this log.

Closes https://github.com/sky-uk/umc-core/issues/2672