### PR TITLE
Fix erroneous reloads due to unsorted map data

### DIFF
--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -103,6 +103,7 @@ type loadBalancerTemplate struct {
 
 type server struct {
 	Name       string
+	Names      []string
 	ServerName string
 	Locations  []*location
 }
@@ -431,12 +432,14 @@ func createServerEntries(update controller.IngressUpdate) []*server {
 		}
 		paths[location.Path] = true
 
-		serverEntry.Name += " " + ingressEntry.NamespaceName()
+		serverEntry.Names = append(serverEntry.Names, ingressEntry.NamespaceName())
 		serverEntry.Locations = append(serverEntry.Locations, &location)
 	}
 
 	var serverEntries []*server
 	for _, serverEntry := range hostToNginxEntry {
+		sort.Strings(serverEntry.Names)
+		serverEntry.Name = strings.Join(serverEntry.Names, " ")
 		sort.Sort(locations(serverEntry.Locations))
 		serverEntries = append(serverEntries, serverEntry)
 	}

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -101,7 +101,7 @@ http {
 {{ end }}
 
 {{- range $entry := .Servers }}
-    # ingress:{{ $entry.Name }}    
+    # ingress: {{ $entry.Name }}
     server {
         listen {{ $port }}{{ if $proxyprotocol }} proxy_protocol{{ end }};
         server_name {{ $entry.ServerName }};

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -678,6 +678,33 @@ func TestNginxIngressEntries(t *testing.T) {
 			nil,
 		},
 		{
+			"Ingress names are ordered in comment to prevent diff generation",
+			defaultConf,
+			[]controller.IngressEntry{
+				{
+					Host:           "chris.com",
+					Namespace:      "core",
+					Name:           "02chris-ingress",
+					Path:           "/my-path",
+					ServiceAddress: "service",
+					ServicePort:    9090,
+				},
+
+				{
+					Host:           "chris.com",
+					Namespace:      "core",
+					Name:           "01chris-ingress",
+					Path:           "/my-path2",
+					ServiceAddress: "service",
+					ServicePort:    9090,
+				},
+			},
+			nil,
+			[]string{
+				"# ingress: core/01chris-ingress core/02chris-ingress",
+			},
+		},
+		{
 			"Disabled path stripping should not put a trailing slash on proxy_pass",
 			defaultConf,
 			[]controller.IngressEntry{


### PR DESCRIPTION
We were reloading almost always due to not sorting the ingress names in
the server comments.