### PR TITLE
Deterministic ordering for duplicate ingresses

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -155,6 +155,7 @@ func (c *controller) updateIngresses() error {
 						ELbScheme:               ingress.Annotations[frontendElbSchemeAnnotation],
 						StripPaths:              c.defaultStripPath,
 						BackendKeepAliveSeconds: c.defaultBackendTimeout,
+						CreationTimestamp:       ingress.CreationTimestamp.Time,
 					}
 
 					if allow, ok := ingress.Annotations[ingressAllowAnnotation]; ok {

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 // IngressUpdate data
@@ -33,6 +34,8 @@ type IngressEntry struct {
 	StripPaths bool
 	// BackendKeepAliveSeconds backend timeout
 	BackendKeepAliveSeconds int
+	// Ingress creation time
+	CreationTimestamp time.Time
 }
 
 // validate returns error if entry has invalid fields.

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -550,35 +550,38 @@ func TestNginxIngressEntries(t *testing.T) {
 			},
 		},
 		{
-			"Duplicate host and paths will only keep the first one",
+			"Duplicate host and paths will only keep the most recent one",
 			defaultConf,
 			[]controller.IngressEntry{
 				{
 					Host:                    "chris.com",
 					Namespace:               "core",
-					Name:                    "chris-ingress-first",
+					Name:                    "chris-ingress-old",
 					Path:                    "/my-path",
 					ServiceAddress:          "service1",
 					ServicePort:             9090,
 					BackendKeepAliveSeconds: 28,
+					CreationTimestamp:       time.Now().Add(-1 * time.Minute),
 				},
 				{
 					Host:                    "chris.com",
 					Namespace:               "core",
-					Name:                    "chris-ingress-second",
+					Name:                    "chris-ingress-most-recent",
 					Path:                    "/my-path",
 					ServiceAddress:          "service2",
 					ServicePort:             9090,
 					BackendKeepAliveSeconds: 28,
+					CreationTimestamp:       time.Now(),
 				},
 				{
 					Host:                    "chris.com",
 					Namespace:               "core",
-					Name:                    "chris-ingress-third",
+					Name:                    "chris-ingress-older",
 					Path:                    "/my-path",
 					ServiceAddress:          "service3",
 					ServicePort:             9090,
 					BackendKeepAliveSeconds: 28,
+					CreationTimestamp:       time.Now().Add(-2 * time.Minute),
 				},
 				{
 					Host:                    "chris-again.com",
@@ -588,6 +591,7 @@ func TestNginxIngressEntries(t *testing.T) {
 					ServiceAddress:          "service4",
 					ServicePort:             9090,
 					BackendKeepAliveSeconds: 28,
+					CreationTimestamp:       time.Now(),
 				},
 			},
 			nil,
@@ -627,7 +631,7 @@ func TestNginxIngressEntries(t *testing.T) {
 					"\n" +
 					"        location /my-path/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service1.9090;\n" +
+					"            proxy_pass http://core.service2.9090;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /my-path/::$proxy_host $server_name;\n" +


### PR DESCRIPTION
Keep the most recent ingress when duplicate ingresses found to make the order
deterministic, so that new feed deployment or reload always keep the same
ingress when duplicates are found.

The inconsistent ordering originates from`Client#GetIngresses` which returns ingresses in a different order even when they do not change. 

Fix sky-uk/umc-core#2764