### PR TITLE
Accept env variables to define version and repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,17 +43,9 @@ test :
 # Docker build 
 ingress_build_dir := build/ingress
 template := ./nginx/nginx.tmpl
-ifdef REPOSITORY
-    repository := $(REPOSITORY)
-else 
-    repository := skycirrus
-endif
-ifdef BUILD_VERSION
-    build_version := $(BUILD_VERSION)
-else 
-    build_version := $(shell git rev-parse --short HEAD)
-endif
 builds := ingress dns
+REPOSITORY=skycirrus
+BUILD_VERSION=$(shell git rev-parse --short HEAD)
 
 clean :
 	@echo "== cleaning"
@@ -78,7 +70,7 @@ docker : copy
 	@echo "== build docker images"
 	@for build in $(builds) ; do \
 	  set -e; \
-	  tag=${repository}/feed-$$build:${build_version} ; \
+	  tag=$(REPOSITORY)/feed-$$build:$(BUILD_VERSION) ; \
 	  docker build -t $$tag build/$${build}/. ; \
 	  echo "Built $$tag" ; \
 	done
@@ -88,22 +80,9 @@ release : docker
 	@docker login -e $(DOCKER_EMAIL) -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
 	@for build in $(builds) ; do \
 	  set -e; \
-	  tag=${repository}/feed-$$build:${build_version} ; \
-	  latest_tag=${repository}/feed-$$build:latest ; \
+	  tag=$(REPOSITORY)/feed-$$build:$(BUILD_VERSION) ; \
+	  latest_tag=$(REPOSITORY)/feed-$$build:latest ; \
 	  docker tag $$tag $$latest_tag ; \
 	  docker push $$tag ; \
-	  docker push $$latest_tag ; \
-	done
-
-releasetotest : docker
-	@echo "== release docker image to the test repository"
-	@for build in $(builds) ; do \
-	  set -e; \
-	  image_tag=${repository}/feed-$$build:${build_version} ; \
-	  test_tag=${repository}/test/feed-$$build:${build_version} ; \
-	  latest_tag=${repository}/test/feed-$$build:latest ; \
-	  docker tag $$image_tag $$test_tag ; \
-	  docker tag $$test_tag $$latest_tag ; \
-	  docker push $$test_tag ; \
 	  docker push $$latest_tag ; \
 	done


### PR DESCRIPTION
To make it easier to test a change before releasing by allowing to specify build version / target
respository to use