### PR TITLE
Wait for drain duration on ELB detach

### DIFF
--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -27,7 +27,7 @@ var (
 	elbLabelValue                  string
 	region                         string
 	elbExpectedNumber              int
-	elbDrainTime                   time.Duration
+	elbDrainDelay                  time.Duration
 	targetGroupNames               cmd.CommaSeparatedValues
 	targetGroupDeregistrationDelay time.Duration
 	pushgatewayURL                 string
@@ -61,8 +61,8 @@ func init() {
 		defaultNginxProxyProtocol                = false
 		defaultNginxUpdatePeriod                 = time.Second * 30
 		defaultElbLabelValue                     = ""
-		defaultElbDrainTime                      = time.Second * 30
-		defaultTargetGroupDeregistrationDelay    = time.Second * 30
+		defaultElbDrainDelay                     = time.Second * 60
+		defaultTargetGroupDeregistrationDelay    = time.Second * 300
 		defaultRegion                            = "eu-west-1"
 		defaultElbExpectedNumber                 = 0
 		defaultPushgatewayIntervalSeconds        = 60
@@ -143,15 +143,15 @@ func init() {
 	flag.IntVar(&elbExpectedNumber, "elb-expected-number", defaultElbExpectedNumber,
 		"Expected number of ELBs to attach to. If 0 the controller will not check,"+
 			" otherwise it fails to start if it can't attach to this number.")
-	flag.DurationVar(&elbDrainTime, "elb-drain-time", defaultElbDrainTime, "Delay to wait"+
-		"for feed-ingress to drain from the ELB on shutdown. Should be slightly larger than the ELB's drain time.")
+	flag.DurationVar(&elbDrainDelay, "elb-drain-delay", defaultElbDrainDelay, "Delay to wait"+
+		" for feed-ingress to drain from the ELB on shutdown. Should match the ELB's drain time.")
 
 	flag.Var(&targetGroupNames, "alb-target-group-names",
 		"Names of ALB target groups to attach to, separated by commas.")
 	flag.DurationVar(&targetGroupDeregistrationDelay, "alb-target-group-deregistration-delay",
 		defaultTargetGroupDeregistrationDelay,
-		"Delay to wait for feed-ingress to deregister from the ALB target group on shutdown. Should be slightly larger"+
-			" than the target group setting in AWS.")
+		"Delay to wait for feed-ingress to deregister from the ALB target group on shutdown. Should match"+
+			" the target group setting in AWS.")
 
 	flag.StringVar(&pushgatewayURL, "pushgateway", "",
 		"Prometheus pushgateway URL for pushing metrics. Leave blank to not push metrics.")
@@ -195,7 +195,7 @@ func createIngressUpdaters() []controller.Updater {
 	nginxConfig.LogHeaders = nginxLogHeaders
 	nginx := nginx.New(nginxConfig)
 
-	elbAttacher := elb.New(region, elbLabelValue, elbExpectedNumber, elbDrainTime)
+	elbAttacher := elb.New(region, elbLabelValue, elbExpectedNumber, elbDrainDelay)
 	albAttacher := alb.New(region, targetGroupNames, targetGroupDeregistrationDelay)
 	// update nginx before attaching to front ends
 	return []controller.Updater{nginx, elbAttacher, albAttacher}

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -10,6 +10,8 @@ import (
 
 	"sync"
 
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -23,7 +25,7 @@ import (
 const ElbTag = "sky.uk/KubernetesClusterFrontend"
 
 // New  creates a new ELB frontend
-func New(region string, labelValue string, expectedNumber int) controller.Updater {
+func New(region string, labelValue string, expectedNumber int, drainTime time.Duration) controller.Updater {
 	initMetrics()
 	log.Infof("ELB Front end region: %s cluster: %s expected frontends: %d", region, labelValue, expectedNumber)
 	metadata := ec2metadata.New(session.New())
@@ -34,6 +36,7 @@ func New(region string, labelValue string, expectedNumber int) controller.Update
 		region:         region,
 		expectedNumber: expectedNumber,
 		initialised:    initialised{},
+		drainTime:      drainTime,
 	}
 }
 
@@ -55,6 +58,7 @@ type elb struct {
 	elbs                map[string]LoadBalancerDetails
 	registeredFrontends int
 	initialised         initialised
+	drainTime           time.Duration
 }
 
 type initialised struct {
@@ -170,7 +174,7 @@ func FindFrontEndElbs(awsElb ELB, labelValue string) (map[string]LoadBalancerDet
 		}
 	}
 
-	log.Infof("Found %d loadbalancers. Checking for %s tag set to %s", len(lbNames), ElbTag, labelValue)
+	log.Debugf("Found %d loadbalancers. Checking for %s tag set to %s", len(lbNames), ElbTag, labelValue)
 	clusterFrontEnds := make(map[string]LoadBalancerDetails)
 	partitions := util.Partition(len(lbNames), maxTagQuery)
 	for _, partition := range partitions {
@@ -215,6 +219,9 @@ func (e *elb) Stop() error {
 	if failed {
 		return errors.New("at least one ELB failed to detach")
 	}
+
+	time.Sleep(e.drainTime)
+
 	return nil
 }
 

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -24,8 +24,8 @@ import (
 // ElbTag is the tag key used for identifying ELBs to attach to.
 const ElbTag = "sky.uk/KubernetesClusterFrontend"
 
-// New  creates a new ELB frontend
-func New(region string, labelValue string, expectedNumber int, drainTime time.Duration) controller.Updater {
+// New creates a new ELB frontend
+func New(region string, labelValue string, expectedNumber int, drainDelay time.Duration) controller.Updater {
 	initMetrics()
 	log.Infof("ELB Front end region: %s cluster: %s expected frontends: %d", region, labelValue, expectedNumber)
 	metadata := ec2metadata.New(session.New())
@@ -36,7 +36,7 @@ func New(region string, labelValue string, expectedNumber int, drainTime time.Du
 		region:         region,
 		expectedNumber: expectedNumber,
 		initialised:    initialised{},
-		drainTime:      drainTime,
+		drainDelay:     drainDelay,
 	}
 }
 
@@ -58,7 +58,7 @@ type elb struct {
 	elbs                map[string]LoadBalancerDetails
 	registeredFrontends int
 	initialised         initialised
-	drainTime           time.Duration
+	drainDelay          time.Duration
 }
 
 type initialised struct {
@@ -220,7 +220,7 @@ func (e *elb) Stop() error {
 		return errors.New("at least one ELB failed to detach")
 	}
 
-	time.Sleep(e.drainTime)
+	time.Sleep(e.drainDelay)
 
 	return nil
 }

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -363,7 +363,7 @@ func TestDeregistersWithAttachedELBs(t *testing.T) {
 	// given
 	e, mockElb, mockMetadata := setup()
 	e.(*elb).expectedNumber = 2
-	e.(*elb).drainTime = time.Millisecond * 100
+	e.(*elb).drainDelay = time.Millisecond * 100
 
 	instanceID := "cow"
 	mockInstanceMetadata(mockMetadata, instanceID)


### PR DESCRIPTION
So feed-ingress deployment is non-disruptive when attached to an ELB.