### PR TITLE
Start Nginx only after first update is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.2
+
+* Fix bug where feed-ingress could return 404s for a brief period upon startup.
+
 # v1.0.1
 
 * Fix bug in feed that causes unhealthy status at startup (https://github.com/sky-uk/feed/pull/141)

--- a/nginx/fake_failing_nginx.sh
+++ b/nginx/fake_failing_nginx.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
 echo $0 $@
-echo "Exiting immediately - failed!"
-exit -1
+if [[ "$1" == "-v" ]]; then
+    echo "Nginx version message"
+else
+    echo "Exiting immediately - failed!"
+    exit -1
+fi

--- a/nginx/fake_graceful_nginx.py
+++ b/nginx/fake_graceful_nginx.py
@@ -29,6 +29,11 @@ signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGQUIT, signal.SIGHUP})
 signal.signal(signal.SIGQUIT, sigquit_handler)
 signal.signal(signal.SIGHUP, sighup_handler)
 signal.pause
+
+startup_marker_file_name = str.join('/', sys.argv[2].split('/')[:-1]) + '/nginx-started'
+with open(startup_marker_file_name, 'w') as f:
+    f.write('started!')
+
 time.sleep(5)
 print('Quit after 5 seconds of nada')
 sys.exit(-1)

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -132,7 +132,11 @@ func (c *Conf) nginxConfFile() string {
 }
 
 // New creates an nginx updater.
-func New(nginxConf Conf) *nginxUpdater {
+func New(nginxConf Conf) controller.Updater {
+	return updaterFromConf(nginxConf)
+}
+
+func updaterFromConf(nginxConf Conf) *nginxUpdater {
 	initMetrics()
 
 	nginxConf.WorkingDir = strings.TrimSuffix(nginxConf.WorkingDir, "/")

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -86,14 +86,14 @@ func (n *nginxUpdater) signalIfRequired() {
 // Nginx implementation
 type nginxUpdater struct {
 	Conf
-	running              	util.SafeBool
-	lastErr              	util.SafeError
-	metricsUnhealthy     	util.SafeBool
-	initialUpdateApplied 	initialUpdateApplied
-	initialUpdateAttempted	util.SafeBool
-	doneCh               	chan struct{}
-	nginx                	*nginx
-	updateRequired       	util.SafeBool
+	running                util.SafeBool
+	lastErr                util.SafeError
+	metricsUnhealthy       util.SafeBool
+	initialUpdateApplied   initialUpdateApplied
+	initialUpdateAttempted util.SafeBool
+	doneCh                 chan struct{}
+	nginx                  *nginx
+	updateRequired         util.SafeBool
 }
 
 type initialUpdateApplied struct {

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -58,7 +58,7 @@ func newUpdaterWithBinary(tmpDir string, binary string) *nginxUpdater {
 }
 
 func newNginxWithConf(conf Conf) *nginxUpdater {
-	lb := New(conf)
+	lb := updaterFromConf(conf)
 	return lb
 }
 

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -137,7 +137,6 @@ func TestUnhealthyIfHealthPortIsNotUp(t *testing.T) {
 	}}}))
 
 	time.Sleep(smallWaitTime)
-
 	assert.EqualError(lb.Health(), "nginx metrics are failing to update")
 }
 


### PR DESCRIPTION
Prior to this change, there was a small window where the Nginx instance
used by feed-ingress could be active but without having loaded its
configuration. In this instance, the load balancer would be able to
reach it, but would receive a 404 response.
    
The solution is to only start Nginx after the first update has been
received and the configuration is ready - this means the load balancer
will only be able to reach it when it is suitably configured.
    
Fixes https://github.com/sky-uk/umc-core/issues/3586