### PR TITLE
Do not delete unassociated A records

### DIFF
--- a/cmd/feed-dns/main.go
+++ b/cmd/feed-dns/main.go
@@ -29,6 +29,7 @@ var (
 	pushgatewayIntervalSeconds int
 	pushgatewayLabels          cmd.KeyValues
 	awsAPIRetries              int
+	r53DelAssocOnly            bool
 )
 
 func init() {
@@ -67,6 +68,8 @@ func init() {
 		"A label=value pair to attach to metrics pushed to prometheus. Specify multiple times for multiple labels.")
 	flag.IntVar(&awsAPIRetries, "aws-api-retries", defaultAwsAPIRetries,
 		"Number of times a request to the AWS API is retried.")
+	flag.BoolVar(&r53DelAssocOnly, "del-assoc-only", false,
+		"Only delete Route53 entries associated with ELBs/ALBs configured with this controller.")
 }
 
 func main() {
@@ -81,7 +84,7 @@ func main() {
 		log.Fatal("Unable to create k8s client: ", err)
 	}
 
-	dnsUpdater := dns.New(r53HostedZone, elbRegion, elbLabelValue, albNames, awsAPIRetries)
+	dnsUpdater := dns.New(r53HostedZone, elbRegion, elbLabelValue, albNames, awsAPIRetries, r53DelAssocOnly)
 
 	controller := controller.New(controller.Config{
 		KubernetesClient: client,

--- a/cmd/feed-dns/main.go
+++ b/cmd/feed-dns/main.go
@@ -29,7 +29,6 @@ var (
 	pushgatewayIntervalSeconds int
 	pushgatewayLabels          cmd.KeyValues
 	awsAPIRetries              int
-	r53DelAssocOnly            bool
 )
 
 func init() {
@@ -68,8 +67,6 @@ func init() {
 		"A label=value pair to attach to metrics pushed to prometheus. Specify multiple times for multiple labels.")
 	flag.IntVar(&awsAPIRetries, "aws-api-retries", defaultAwsAPIRetries,
 		"Number of times a request to the AWS API is retried.")
-	flag.BoolVar(&r53DelAssocOnly, "del-assoc-only", false,
-		"Only delete Route53 entries associated with ELBs/ALBs configured with this controller.")
 }
 
 func main() {
@@ -84,7 +81,7 @@ func main() {
 		log.Fatal("Unable to create k8s client: ", err)
 	}
 
-	dnsUpdater := dns.New(r53HostedZone, elbRegion, elbLabelValue, albNames, awsAPIRetries, r53DelAssocOnly)
+	dnsUpdater := dns.New(r53HostedZone, elbRegion, elbLabelValue, albNames, awsAPIRetries)
 
 	controller := controller.New(controller.Config{
 		KubernetesClient: client,

--- a/dns/dns_updater.go
+++ b/dns/dns_updater.go
@@ -97,6 +97,10 @@ func (u *updater) initELBs() error {
 
 	u.schemeToDNS = make(map[string]dnsDetails)
 	for scheme, lbDetails := range elbs {
+		if strings.HasSuffix(lbDetails.DNSName, ".") {
+			return fmt.Errorf("unexpected trailing dot on load balancer DNS name: %s", lbDetails.DNSName)
+		}
+
 		u.schemeToDNS[scheme] = dnsDetails{dnsName: lbDetails.DNSName + ".", hostedZoneID: lbDetails.HostedZoneID}
 	}
 

--- a/dns/dns_updater_test.go
+++ b/dns/dns_updater_test.go
@@ -110,8 +110,8 @@ func (m *mockR53Client) mockGetHostedZoneDomain() {
 	m.On("GetHostedZoneDomain").Return(domain, nil)
 }
 
-func setup(onlyDelAssoc bool) (*updater, *mockR53Client, *mockALB) {
-	dnsUpdater := New(hostedZoneID, awsRegion, "", albNames, 1, onlyDelAssoc).(*updater)
+func setup() (*updater, *mockR53Client, *mockALB) {
+	dnsUpdater := New(hostedZoneID, awsRegion, "", albNames, 1).(*updater)
 	mockR53 := &mockR53Client{}
 	dnsUpdater.r53 = mockR53
 	mockALB := &mockALB{}
@@ -120,7 +120,7 @@ func setup(onlyDelAssoc bool) (*updater, *mockR53Client, *mockALB) {
 }
 
 func TestFailsToQueryFrontends(t *testing.T) {
-	dnsUpdater, mockR53, mockALB := setup(false)
+	dnsUpdater, mockR53, mockALB := setup()
 	mockALB.mockDescribeLoadBalancers(albNames, nil, errors.New("doh"))
 	mockR53.mockGetHostedZoneDomain()
 
@@ -130,7 +130,7 @@ func TestFailsToQueryFrontends(t *testing.T) {
 }
 
 func TestGetsDomainNameFails(t *testing.T) {
-	dnsUpdater, mockR53, mockALB := setup(false)
+	dnsUpdater, mockR53, mockALB := setup()
 	mockALB.mockDescribeLoadBalancers(albNames, lbDetails, nil)
 	mockR53.On("GetHostedZoneDomain").Return("", errors.New("No domain for you"))
 
@@ -141,7 +141,7 @@ func TestGetsDomainNameFails(t *testing.T) {
 
 func TestUpdateRecordSetFail(t *testing.T) {
 	// given
-	dnsUpdater, mockR53, mockALB := setup(false)
+	dnsUpdater, mockR53, mockALB := setup()
 	mockR53.mockGetHostedZoneDomain()
 	mockR53.mockGetARecords(nil, nil)
 	mockALB.mockDescribeLoadBalancers(albNames, lbDetails, nil)
@@ -162,21 +162,18 @@ func TestUpdateRecordSetFail(t *testing.T) {
 func TestRecordSetUpdates(t *testing.T) {
 	var tests = []struct {
 		name            string
-		onlyDelAssoc    bool
 		update          controller.IngressUpdate
 		records         []*route53.ResourceRecordSet
 		expectedChanges []*route53.Change
 	}{
 		{
 			"Empty update has no change",
-			false,
 			controller.IngressUpdate{},
 			[]*route53.ResourceRecordSet{},
 			[]*route53.Change{},
 		},
 		{
 			"Add new record",
-			false,
 			controller.IngressUpdate{Entries: []controller.IngressEntry{{
 				Name:        "test-entry",
 				Host:        "cats.james.com",
@@ -200,7 +197,6 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Updating existing record to a new elb schema",
-			false,
 			controller.IngressUpdate{Entries: []controller.IngressEntry{{
 				Name:        "test-entry",
 				Host:        "foo.james.com",
@@ -231,56 +227,6 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Deleting existing record",
-			false,
-			controller.IngressUpdate{},
-			[]*route53.ResourceRecordSet{
-				{
-					Name: aws.String("foo.com."),
-					AliasTarget: &route53.AliasTarget{
-						DNSName:              aws.String(internalALBDnsNameWithPeriod),
-						HostedZoneId:         aws.String(lbHostedZoneID),
-						EvaluateTargetHealth: aws.Bool(false),
-					},
-				},
-				{
-					Name: aws.String("bar.com."),
-					AliasTarget: &route53.AliasTarget{
-						DNSName:              aws.String(unassocALBDnsNameWithPeriod),
-						HostedZoneId:         aws.String(lbHostedZoneID),
-						EvaluateTargetHealth: aws.Bool(false),
-					},
-				},
-			},
-			[]*route53.Change{
-				{
-					Action: aws.String("DELETE"),
-					ResourceRecordSet: &route53.ResourceRecordSet{
-						Name: aws.String("foo.com."),
-						Type: aws.String("A"),
-						AliasTarget: &route53.AliasTarget{
-							DNSName:              aws.String(internalALBDnsNameWithPeriod),
-							HostedZoneId:         aws.String(lbHostedZoneID),
-							EvaluateTargetHealth: aws.Bool(false),
-						},
-					},
-				},
-				{
-					Action: aws.String("DELETE"),
-					ResourceRecordSet: &route53.ResourceRecordSet{
-						Name: aws.String("bar.com."),
-						Type: aws.String("A"),
-						AliasTarget: &route53.AliasTarget{
-							DNSName:              aws.String(unassocALBDnsNameWithPeriod),
-							HostedZoneId:         aws.String(lbHostedZoneID),
-							EvaluateTargetHealth: aws.Bool(false),
-						},
-					},
-				},
-			},
-		},
-		{
-			"Does not deleted unassociated existing record",
-			true,
 			controller.IngressUpdate{},
 			[]*route53.ResourceRecordSet{
 				{
@@ -315,7 +261,6 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Adding and deleting records",
-			false,
 			controller.IngressUpdate{Entries: []controller.IngressEntry{{
 				Name:        "test-entry",
 				Host:        "foo.james.com",
@@ -323,14 +268,24 @@ func TestRecordSetUpdates(t *testing.T) {
 				ELbScheme:   internalScheme,
 				ServicePort: 80,
 			}}},
-			[]*route53.ResourceRecordSet{{
-				Name: aws.String("bar.james.com."),
-				AliasTarget: &route53.AliasTarget{
-					DNSName:              aws.String(internalALBDnsNameWithPeriod),
-					HostedZoneId:         aws.String(lbHostedZoneID),
-					EvaluateTargetHealth: aws.Bool(false),
+			[]*route53.ResourceRecordSet{
+				{
+					Name: aws.String("bar.james.com."),
+					AliasTarget: &route53.AliasTarget{
+						DNSName:              aws.String(internalALBDnsNameWithPeriod),
+						HostedZoneId:         aws.String(lbHostedZoneID),
+						EvaluateTargetHealth: aws.Bool(false),
+					},
 				},
-			}},
+				{
+					Name: aws.String("baz.james.com."),
+					AliasTarget: &route53.AliasTarget{
+						DNSName:              aws.String(unassocALBDnsNameWithPeriod),
+						HostedZoneId:         aws.String(lbHostedZoneID),
+						EvaluateTargetHealth: aws.Bool(false),
+					},
+				},
+			},
 			[]*route53.Change{{
 				Action: aws.String("UPSERT"),
 				ResourceRecordSet: &route53.ResourceRecordSet{
@@ -358,7 +313,6 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Non-matching schemes and domains are ignored",
-			false,
 			controller.IngressUpdate{Entries: []controller.IngressEntry{
 				// host doesn't match james.com.
 				{
@@ -382,7 +336,6 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Duplicate hosts are not duplicated in changeset",
-			false,
 			controller.IngressUpdate{Entries: []controller.IngressEntry{
 				{
 					Name:        "test-entry",
@@ -422,7 +375,6 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Should choose first conflicting scheme",
-			false,
 			controller.IngressUpdate{Entries: []controller.IngressEntry{
 				{
 					Name:        "test-entry",
@@ -455,7 +407,6 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Does not update records when current and new entry are the same",
-			false,
 			controller.IngressUpdate{Entries: []controller.IngressEntry{{
 				Name:        "test-entry",
 				Host:        "foo.james.com",
@@ -478,7 +429,7 @@ func TestRecordSetUpdates(t *testing.T) {
 	for _, test := range tests {
 		fmt.Printf("=== test: %s\n", test.name)
 
-		dnsUpdater, mockR53, mockALB := setup(test.onlyDelAssoc)
+		dnsUpdater, mockR53, mockALB := setup()
 		mockALB.mockDescribeLoadBalancers(albNames, lbDetails, nil)
 		mockR53.mockGetHostedZoneDomain()
 		mockR53.mockGetARecords(test.records, nil)


### PR DESCRIPTION
We found ourselves wanting to use `feed-dns` with a Route 53 zone that was already populated with existing records.  To facilitate this, we added a switch to allow `feed-dns` to only clean up records which alias existing load balancers that match feed's selection criteria.  While this does mean the cleanup could potentially leave records pointing to load balancers that have been deleted, we felt that this was a rare enough case to be a fair trade off for the ability to use the service with an existing zone.