### PR TITLE
Make deduping ingress entries deterministic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.8.1
 
 before_install:
   - sudo add-apt-repository -y ppa:jonathonf/python-3.6

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -71,7 +71,7 @@ func (a *alb) Start() error {
 	return nil
 }
 
-func (a *alb) Update(controller.IngressUpdate) error {
+func (a *alb) Update(controller.IngressEntries) error {
 	a.initialised.Lock()
 	defer a.initialised.Unlock()
 	defer func() { a.readyForHealthCheck.Set(true) }()

--- a/alb/alb_test.go
+++ b/alb/alb_test.go
@@ -123,7 +123,7 @@ func TestNoopIfNoExpectedFrontEnds(t *testing.T) {
 
 	//when
 	a.Start()
-	a.Update(controller.IngressUpdate{})
+	a.Update(controller.IngressEntries{})
 	a.Stop()
 
 	//then
@@ -143,7 +143,7 @@ func TestRegisterInstance(t *testing.T) {
 
 	//when
 	err := a.Start()
-	updateErr := a.Update(controller.IngressUpdate{})
+	updateErr := a.Update(controller.IngressEntries{})
 
 	//then
 	mockALB.AssertExpectations(t)
@@ -165,7 +165,7 @@ func TestReportsErrorIfDidntRegisterAllTargetGroups(t *testing.T) {
 
 	//when
 	err := a.Start()
-	updateErr := a.Update(controller.IngressUpdate{})
+	updateErr := a.Update(controller.IngressEntries{})
 
 	//then
 	assert.NoError(t, err)
@@ -177,7 +177,7 @@ func TestErrorGettingMetadata(t *testing.T) {
 	mockMetadata.On("GetInstanceIdentityDocument").
 		Return(ec2metadata.EC2InstanceIdentityDocument{}, errors.New("no metadata for you"))
 
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	assert.Error(t, err)
 }
@@ -191,7 +191,7 @@ func TestErrorDescribingTargetGroups(t *testing.T) {
 
 	//when
 	a.Start()
-	updateErr := a.Update(controller.IngressUpdate{})
+	updateErr := a.Update(controller.IngressEntries{})
 
 	//then
 	assert.Error(t, updateErr)
@@ -208,7 +208,7 @@ func TestMissingTargetGroups(t *testing.T) {
 
 	//when
 	err := a.Start()
-	updateErr := a.Update(controller.IngressUpdate{})
+	updateErr := a.Update(controller.IngressEntries{})
 
 	//then
 	assert.NoError(t, err)
@@ -229,7 +229,7 @@ func TestDescribeTargetGroupPages(t *testing.T) {
 
 	//when
 	err := a.Start()
-	updateErr := a.Update(controller.IngressUpdate{})
+	updateErr := a.Update(controller.IngressEntries{})
 
 	//then
 	mockALB.AssertExpectations(t)
@@ -252,7 +252,7 @@ func TestDeregistersOnStop(t *testing.T) {
 
 	//when
 	a.Start()
-	a.Update(controller.IngressUpdate{})
+	a.Update(controller.IngressEntries{})
 	stopErr := a.Stop()
 
 	//then
@@ -275,7 +275,7 @@ func TestDeregisterErrorIsHandledInStop(t *testing.T) {
 
 	//when
 	a.Start()
-	a.Update(controller.IngressUpdate{})
+	a.Update(controller.IngressEntries{})
 	stopErr := a.Stop()
 
 	//then
@@ -323,7 +323,7 @@ func TestHealthReportsUnhealthyAfterUnsuccessfulFirstUpdate(t *testing.T) {
 
 	//when
 	err := a.Start()
-	updateErr := a.Update(controller.IngressUpdate{})
+	updateErr := a.Update(controller.IngressEntries{})
 
 	//then
 	assert.NoError(t, err)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -198,9 +198,8 @@ func (c *controller) updateIngresses() error {
 		log.Infof("Skipped %d invalid: %s", len(skipped), strings.Join(skipped, ", "))
 	}
 
-	update := IngressUpdate{Entries: entries}
 	for _, u := range c.updaters {
-		if err := u.Update(update); err != nil {
+		if err := u.Update(entries); err != nil {
 			return err
 		}
 	}

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -6,9 +6,24 @@ import (
 	"time"
 )
 
-// IngressUpdate data
-type IngressUpdate struct {
-	Entries []IngressEntry
+// IngressEntries type
+type IngressEntries []IngressEntry
+
+// allows us to sort ingress entries.
+func (entries IngressEntries) Len() int {
+	return len(entries)
+}
+
+// allows us to sort ingress entries.
+func (entries IngressEntries) Less(i, j int) bool {
+	iEntry := fmt.Sprintf("%s:%s:%s:%s", entries[i].Namespace, entries[i].Name, entries[i].Host, entries[i].Path)
+	jEntry := fmt.Sprintf("%s:%s:%s:%s", entries[j].Namespace, entries[j].Name, entries[j].Host, entries[j].Path)
+	return iEntry < jEntry
+}
+
+// allows us to sort ingress entries.
+func (entries IngressEntries) Swap(i, j int) {
+	entries[i], entries[j] = entries[j], entries[i]
 }
 
 // IngressEntry describes the ingress for a single host, path, and service.

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -9,23 +9,6 @@ import (
 // IngressEntries type
 type IngressEntries []IngressEntry
 
-// allows us to sort ingress entries.
-func (entries IngressEntries) Len() int {
-	return len(entries)
-}
-
-// allows us to sort ingress entries.
-func (entries IngressEntries) Less(i, j int) bool {
-	iEntry := fmt.Sprintf("%s:%s:%s:%s", entries[i].Namespace, entries[i].Name, entries[i].Host, entries[i].Path)
-	jEntry := fmt.Sprintf("%s:%s:%s:%s", entries[j].Namespace, entries[j].Name, entries[j].Host, entries[j].Path)
-	return iEntry < jEntry
-}
-
-// allows us to sort ingress entries.
-func (entries IngressEntries) Swap(i, j int) {
-	entries[i], entries[j] = entries[j], entries[i]
-}
-
 // IngressEntry describes the ingress for a single host, path, and service.
 type IngressEntry struct {
 	// Namespace of the ingress.

--- a/controller/updater.go
+++ b/controller/updater.go
@@ -8,7 +8,7 @@ type Updater interface {
 	Stop() error
 	// Update the ingress updater configuration.
 	// Not thread safe, should only be called by a single go routine
-	Update(IngressUpdate) error
+	Update(IngressEntries) error
 	// Health returns nil if healthy, otherwise an error. Should be fast to respond, as it
 	// may be called often. Any long running checks should be done separately.
 	Health() error

--- a/dns/dns_updater.go
+++ b/dns/dns_updater.go
@@ -143,7 +143,7 @@ func (u *updater) Health() error {
 	return nil
 }
 
-func (u *updater) Update(update controller.IngressUpdate) error {
+func (u *updater) Update(entries controller.IngressEntries) error {
 	aRecords, err := u.r53.GetARecords()
 	if err != nil {
 		log.Warn("Unable to get A records from Route53. Not updating Route53.", err)
@@ -154,7 +154,7 @@ func (u *updater) Update(update controller.IngressUpdate) error {
 	aRecords = u.determineManagedRecordSets(aRecords)
 	recordsGauge.Set(float64(len(aRecords)))
 
-	changes := u.calculateChanges(aRecords, update)
+	changes := u.calculateChanges(aRecords, entries)
 
 	updateCount.Add(float64(len(changes)))
 
@@ -190,12 +190,12 @@ func (u *updater) determineManagedRecordSets(rrs []*route53.ResourceRecordSet) [
 }
 
 func (u *updater) calculateChanges(originalRecords []*route53.ResourceRecordSet,
-	update controller.IngressUpdate) []*route53.Change {
+	entries controller.IngressEntries) []*route53.Change {
 
 	log.Infof("Current %s records: %v", u.domain, originalRecords)
-	log.Debug("Processing ingress update: ", update)
+	log.Debug("Processing ingress update: ", entries)
 
-	hostToIngress, skipped := u.indexByHost(update.Entries)
+	hostToIngress, skipped := u.indexByHost(entries)
 	changes, skipped2 := u.createChanges(hostToIngress, originalRecords)
 
 	skipped = append(skipped, skipped2...)

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -234,7 +234,7 @@ func (e *elb) Health() error {
 	return fmt.Errorf("expected ELBs: %d actual: %d", e.expectedNumber, e.registeredFrontends.Get())
 }
 
-func (e *elb) Update(controller.IngressUpdate) error {
+func (e *elb) Update(controller.IngressEntries) error {
 	e.initialised.Lock()
 	defer e.initialised.Unlock()
 	defer func() { e.readyForHealthCheck.Set(true) }()

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -145,7 +145,7 @@ func TestNoopIfNoExpectedFrontEnds(t *testing.T) {
 
 	//when
 	e.Start()
-	e.Update(controller.IngressUpdate{})
+	e.Update(controller.IngressEntries{})
 	e.Stop()
 
 	//then
@@ -174,7 +174,7 @@ func TestAttachWithSingleMatchingLoadBalancers(t *testing.T) {
 	err := e.Start()
 
 	//when
-	e.Update(controller.IngressUpdate{})
+	e.Update(controller.IngressEntries{})
 
 	//then
 	assert.NoError(t, e.Health())
@@ -204,7 +204,7 @@ func TestReportsErrorIfExpectedNotMatched(t *testing.T) {
 
 	//when
 	e.Start()
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	//then
 	assert.EqualError(t, err, "expected ELBs: 2 actual: 1")
@@ -249,7 +249,7 @@ func TestAttachWithInternalAndInternetFacing(t *testing.T) {
 
 	//when
 	err := e.Start()
-	e.Update(controller.IngressUpdate{})
+	e.Update(controller.IngressEntries{})
 
 	//then
 	mockElb.AssertExpectations(t)
@@ -261,7 +261,7 @@ func TestErrorGettingMetadata(t *testing.T) {
 	e, _, mockMetadata := setup()
 	mockMetadata.On("GetInstanceIdentityDocument").Return(ec2metadata.EC2InstanceIdentityDocument{}, fmt.Errorf("No metadata for you"))
 
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	assert.EqualError(t, err, "unable to query ec2 metadata service for InstanceId: No metadata for you")
 }
@@ -273,7 +273,7 @@ func TestErrorDescribingInstances(t *testing.T) {
 	mockElb.On("DescribeLoadBalancers", mock.AnythingOfType("*elb.DescribeLoadBalancersInput")).Return(&aws_elb.DescribeLoadBalancersOutput{}, errors.New("oh dear oh dear"))
 
 	e.Start()
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	assert.EqualError(t, err, "unable to describe load balancers: oh dear oh dear")
 }
@@ -286,7 +286,7 @@ func TestErrorDescribingTags(t *testing.T) {
 	mockElb.On("DescribeTags", mock.AnythingOfType("*elb.DescribeTagsInput")).Return(&aws_elb.DescribeTagsOutput{}, errors.New("oh dear oh dear"))
 
 	e.Start()
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	assert.EqualError(t, err, "unable to describe tags: oh dear oh dear")
 }
@@ -303,7 +303,7 @@ func TestNoMatchingElbs(t *testing.T) {
 
 	// when
 	e.Start()
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	// then
 	assert.Error(t, err, "expected ELBs: 1 actual: 0")
@@ -327,7 +327,7 @@ func TestGetLoadBalancerPages(t *testing.T) {
 	mockRegisterInstances(mockElb, loadBalancerName, instanceID)
 
 	// when
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	// then
 	assert.NoError(t, err)
@@ -352,7 +352,7 @@ func TestTagCallsPage(t *testing.T) {
 	mockRegisterInstances(mockElb, loadBalancerName2, instanceID)
 
 	// when
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	// then
 	assert.NoError(t, err)
@@ -396,7 +396,7 @@ func TestDeregistersWithAttachedELBs(t *testing.T) {
 
 	//when
 	assert.NoError(t, e.Start())
-	assert.NoError(t, e.Update(controller.IngressUpdate{}))
+	assert.NoError(t, e.Update(controller.IngressEntries{}))
 	beforeStop := time.Now()
 	assert.NoError(t, e.Stop())
 	stopDuration := time.Now().Sub(beforeStop)
@@ -420,7 +420,7 @@ func TestRegisterInstanceError(t *testing.T) {
 	mockElb.On("RegisterInstancesWithLoadBalancer", mock.Anything).Return(&aws_elb.RegisterInstancesWithLoadBalancerOutput{}, errors.New("no register for you"))
 
 	// when
-	err := e.Update(controller.IngressUpdate{})
+	err := e.Update(controller.IngressEntries{})
 
 	// then
 	assert.EqualError(t, err, "unable to register instance cow with elb cluster-frontend: no register for you")
@@ -442,7 +442,7 @@ func TestDeRegisterInstanceError(t *testing.T) {
 
 	// when
 	e.Start()
-	e.Update(controller.IngressUpdate{})
+	e.Update(controller.IngressEntries{})
 	err := e.Stop()
 
 	// then
@@ -466,8 +466,8 @@ func TestRetriesUpdateIfFirstAttemptFails(t *testing.T) {
 
 	// when
 	e.Start()
-	firstErr := e.Update(controller.IngressUpdate{})
-	secondErr := e.Update(controller.IngressUpdate{})
+	firstErr := e.Update(controller.IngressEntries{})
+	secondErr := e.Update(controller.IngressEntries{})
 
 	// then
 	assert.Error(t, firstErr)
@@ -503,7 +503,7 @@ func TestHealthReportsUnhealthyAfterUnsuccessfulFirstUpdate(t *testing.T) {
 
 	// when
 	err := e.Start()
-	updateErr := e.Update(controller.IngressUpdate{})
+	updateErr := e.Update(controller.IngressEntries{})
 
 	// then
 	assert.NoError(t, err)

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -465,11 +465,17 @@ type ingressKey struct {
 	Host, Path string
 }
 
-func uniqueIngressEntries(ingressEntries controller.IngressEntries) []controller.IngressEntry {
-	sort.Sort(ingressEntries)
+func uniqueIngressEntries(entries controller.IngressEntries) []controller.IngressEntry {
+	sort.Slice(entries, func(i, j int) bool {
+		iEntry := entries[i]
+		jEntry := entries[j]
+		iString := strings.Join([]string{iEntry.Namespace, iEntry.Name, iEntry.Host, iEntry.Path}, "")
+		jString := strings.Join([]string{jEntry.Namespace, jEntry.Name, jEntry.Host, jEntry.Path}, "")
+		return iString < jString
+	})
 
 	uniqueIngress := make(map[ingressKey]controller.IngressEntry)
-	for _, ingressEntry := range ingressEntries {
+	for _, ingressEntry := range entries {
 		key := ingressKey{ingressEntry.Host, ingressEntry.Path}
 		existingIngressEntry, exists := uniqueIngress[key]
 		if !exists {

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -469,8 +469,8 @@ func uniqueIngressEntries(entries controller.IngressEntries) []controller.Ingres
 	sort.Slice(entries, func(i, j int) bool {
 		iEntry := entries[i]
 		jEntry := entries[j]
-		iString := strings.Join([]string{iEntry.Namespace, iEntry.Name, iEntry.Host, iEntry.Path}, ":^^:")
-		jString := strings.Join([]string{jEntry.Namespace, jEntry.Name, jEntry.Host, jEntry.Path}, ":^^:")
+		iString := strings.Join([]string{iEntry.Namespace, iEntry.Name, iEntry.Host, iEntry.Path}, ":")
+		jString := strings.Join([]string{jEntry.Namespace, jEntry.Name, jEntry.Host, jEntry.Path}, ":")
 		return iString < jString
 	})
 

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -469,8 +469,8 @@ func uniqueIngressEntries(entries controller.IngressEntries) []controller.Ingres
 	sort.Slice(entries, func(i, j int) bool {
 		iEntry := entries[i]
 		jEntry := entries[j]
-		iString := strings.Join([]string{iEntry.Namespace, iEntry.Name, iEntry.Host, iEntry.Path}, "")
-		jString := strings.Join([]string{jEntry.Namespace, jEntry.Name, jEntry.Host, jEntry.Path}, "")
+		iString := strings.Join([]string{iEntry.Namespace, iEntry.Name, iEntry.Host, iEntry.Path}, ":^^:")
+		jString := strings.Join([]string{jEntry.Namespace, jEntry.Name, jEntry.Host, jEntry.Path}, ":^^:")
 		return iString < jString
 	})
 


### PR DESCRIPTION
The previous approach tried to order ingress by CreationTimestamp before
picking the most recent ingress.  This did not work because multiple
duplicate ingresses could be created at the same time.

This fix orders ingress entries by Namespace,Name,Host,Path and only
uses the first ingress 'Host/Path' encountered to dedupe.  Kuberentes
guarentees unique ingress for a given 'Namespace/Name' which will make
this deduping deterministic.

fixes: https://github.com/sky-uk/umc-core/issues/3793