### PR TITLE
Avoid duplicate deregistration delay in both ALB/ELB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.1.2
+
+* Fix bug where feed-ingress would wait for `elb-drain-delay` and `alb-target-group-deregistration-delay`
+  even if no instances where attached.
+* Do not create ELB or ALB updater when `elb-label-value` or `alb-target-group-names`,
+  respectively, are empty.
+
 # v1.1.1
 
 Make deduping ingress entries deterministic.
@@ -10,8 +17,6 @@ This fix orders ingress entries by Namespace,Name,Host,Path and only
 uses the first ingress 'Host/Path' encountered to dedupe.  Kubernetes
 guarentees unique ingress for a given 'Namespace/Name' which will make
 this deduping deterministic.
-
-fixes: https://github.com/sky-uk/umc-core/issues/3793
 
 # v1.1.0
 

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -103,7 +103,10 @@ func (a *alb) Stop() error {
 		}
 	}
 
-	time.Sleep(a.targetGroupDeregistrationDelay)
+	if len(a.albARNs) > 0 {
+		log.Infof("Waiting %vs to finish ALB target group deregistration", a.targetGroupDeregistrationDelay)
+		time.Sleep(a.targetGroupDeregistrationDelay)
+	}
 
 	return nil
 }

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -4,6 +4,7 @@ Package alb provides an updater for an ALB frontend to attach nginx to.
 package alb
 
 import (
+	"errors"
 	"fmt"
 
 	"sync"
@@ -22,7 +23,7 @@ import (
 // New creates a controller.Updater for attaching to ALB target groups on first update.
 func New(region string, targetGroupNames []string, targetGroupDeregistrationDelay time.Duration) (controller.Updater, error) {
 	if len(targetGroupNames) == 0 {
-		return nil, fmt.Errorf("Unable to create Alb Updater: missing target group names")
+		return nil, errors.New("unable to create ALB updater: missing target group names")
 	}
 	initMetrics()
 	log.Infof("ALB frontend region: %s target groups: %v", region, targetGroupNames)
@@ -106,7 +107,7 @@ func (a *alb) Stop() error {
 		}
 	}
 
-	log.Infof("Waiting %vs to finish ALB target group deregistration", a.targetGroupDeregistrationDelay)
+	log.Infof("Waiting %v to finish ALB target group deregistration", a.targetGroupDeregistrationDelay)
 	time.Sleep(a.targetGroupDeregistrationDelay)
 
 	return nil

--- a/alb/alb_test.go
+++ b/alb/alb_test.go
@@ -121,7 +121,7 @@ func TestCanNotCreateUpdaterWithoutLabelValue(t *testing.T) {
 	_, err := New(region, []string{}, time.Nanosecond)
 
 	//then
-	assert.EqualError(t, err, "Unable to create Alb Updater: missing target group names")
+	assert.Error(t, err)
 }
 
 func TestRegisterInstance(t *testing.T) {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -235,7 +235,7 @@ func (c *controller) Stop() error {
 	close(c.doneCh)
 
 	for i := range c.updaters {
-		u := c.updaters[len(c.updaters)-i-1]
+		u := c.updaters[len(c.updaters)-1-i]
 		if err := u.Stop(); err != nil {
 			log.Warnf("Error while stopping %v: %v", u, err)
 		}

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -91,10 +91,6 @@ func (e *elb) Start() error {
 }
 
 func (e *elb) attachToFrontEnds() error {
-	if e.labelValue == "" {
-		return nil
-	}
-
 	id, err := e.metadata.GetInstanceIdentityDocument()
 	if err != nil {
 		return fmt.Errorf("unable to query ec2 metadata service for InstanceId: %v", err)

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -25,7 +25,10 @@ import (
 const ElbTag = "sky.uk/KubernetesClusterFrontend"
 
 // New creates a new ELB frontend
-func New(region string, labelValue string, expectedNumber int, drainDelay time.Duration) controller.Updater {
+func New(region string, labelValue string, expectedNumber int, drainDelay time.Duration) (controller.Updater, error) {
+	if labelValue == "" {
+		return nil, fmt.Errorf("Unable to create Elb Updater: Missing label value for the tag %v", ElbTag)
+	}
 	initMetrics()
 	log.Infof("ELB Front end region: %s cluster: %s expected frontends: %d", region, labelValue, expectedNumber)
 	metadata := ec2metadata.New(session.New())
@@ -37,7 +40,7 @@ func New(region string, labelValue string, expectedNumber int, drainDelay time.D
 		expectedNumber: expectedNumber,
 		initialised:    initialised{},
 		drainDelay:     drainDelay,
-	}
+	}, nil
 }
 
 // LoadBalancerDetails stores all the elb information we use.
@@ -221,10 +224,9 @@ func (e *elb) Stop() error {
 		return errors.New("at least one ELB failed to detach")
 	}
 
-	if len(e.elbs) > 0 {
-		log.Infof("Waiting %vs to finish ELB deregistration", e.drainDelay)
-		time.Sleep(e.drainDelay)
-	}
+	log.Infof("Waiting %vs to finish ELB deregistration", e.drainDelay)
+	time.Sleep(e.drainDelay)
+
 	return nil
 }
 

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -27,7 +27,7 @@ const ElbTag = "sky.uk/KubernetesClusterFrontend"
 // New creates a new ELB frontend
 func New(region string, labelValue string, expectedNumber int, drainDelay time.Duration) (controller.Updater, error) {
 	if labelValue == "" {
-		return nil, fmt.Errorf("Unable to create Elb Updater: Missing label value for the tag %v", ElbTag)
+		return nil, fmt.Errorf("unable to create ELB updater: missing label value for the tag %v", ElbTag)
 	}
 	initMetrics()
 	log.Infof("ELB Front end region: %s cluster: %s expected frontends: %d", region, labelValue, expectedNumber)
@@ -220,7 +220,7 @@ func (e *elb) Stop() error {
 		return errors.New("at least one ELB failed to detach")
 	}
 
-	log.Infof("Waiting %vs to finish ELB deregistration", e.drainDelay)
+	log.Infof("Waiting %v to finish ELB deregistration", e.drainDelay)
 	time.Sleep(e.drainDelay)
 
 	return nil

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -221,8 +221,10 @@ func (e *elb) Stop() error {
 		return errors.New("at least one ELB failed to detach")
 	}
 
-	time.Sleep(e.drainDelay)
-
+	if len(e.elbs) > 0 {
+		log.Infof("Waiting %vs to finish ELB deregistration", e.drainDelay)
+		time.Sleep(e.drainDelay)
+	}
 	return nil
 }
 

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -407,6 +407,26 @@ func TestDeregistersWithAttachedELBs(t *testing.T) {
 		"Drain time should have caused stop to take at least 50ms.")
 }
 
+func TestDoesNotWaitToDeregisterIfNoExpectedFrontEnds(t *testing.T) {
+	//given
+	e, mockElb, mockMetadata := setup()
+	e.(*elb).labelValue = ""
+	e.(*elb).drainDelay = time.Millisecond * 100
+
+	//when
+	e.Start()
+	e.Update(controller.IngressEntries{})
+	beforeStop := time.Now()
+	e.Stop()
+	stopDuration := time.Now().Sub(beforeStop)
+
+	//then
+	mockElb.AssertExpectations(t)
+	mockMetadata.AssertExpectations(t)
+	assert.True(t, stopDuration.Nanoseconds() < time.Millisecond.Nanoseconds()*10,
+		"No drain time expected as no deregistration needed.")
+}
+
 func TestRegisterInstanceError(t *testing.T) {
 	// given
 	e, mockElb, mockMetadata := setup()

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -143,7 +143,7 @@ func TestCanNotCreateUpdaterWithoutLabelValue(t *testing.T) {
 	_, err := New(region, "", 1, 0)
 
 	//then
-	assert.EqualError(t, err, "Unable to create Elb Updater: Missing label value for the tag "+ElbTag)
+	assert.Error(t, err)
 }
 
 func TestAttachWithSingleMatchingLoadBalancers(t *testing.T) {

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -146,21 +146,6 @@ func TestCanNotCreateUpdaterWithoutLabelValue(t *testing.T) {
 	assert.EqualError(t, err, "Unable to create Elb Updater: Missing label value for the tag "+ElbTag)
 }
 
-func TestNoopIfNoExpectedFrontEnds(t *testing.T) {
-	//given
-	e, mockElb, mockMetadata := setup()
-	e.(*elb).labelValue = ""
-
-	//when
-	e.Start()
-	e.Update(controller.IngressEntries{})
-	e.Stop()
-
-	//then
-	mockElb.AssertExpectations(t)
-	mockMetadata.AssertExpectations(t)
-}
-
 func TestAttachWithSingleMatchingLoadBalancers(t *testing.T) {
 	// given
 	e, mockElb, mockMetadata := setup()


### PR DESCRIPTION
Avoid waiting deregistration time for alb/elb if there were no attached
instances, even if one was provided.
