### PR TITLE
Aggressively rotate feed access logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.1
+* Aggressively rotate access logs to avoid excessive file cache usage. This can lead to kernel 
+  allocation failures when running feed inside a container with a memory limit.
+
 # v1.2.0
 * Rename annotation `sky.uk/backend-keepalive-seconds` to `sky.uk/backend-timeout-seconds` to make it
   clear that this value only affects request timeouts. The old annotation is preserved for backwards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v1.2.1
-* Aggressively rotate access logs to avoid excessive file cache usage. This can lead to kernel 
+* Aggressively rotate access logs to avoid excessive file cache usage. This can lead to kernel
   allocation failures when running feed inside a container with a memory limit.
 
 # v1.2.0

--- a/docker/ingress/Dockerfile
+++ b/docker/ingress/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.19
+FROM phusion/baseimage:0.9.22
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \
@@ -33,8 +33,10 @@ RUN chmod 600 /etc/cron.d/nginx
 ADD log-dir-ownership.sh /etc/my_init.d/log-dir-ownership.sh
 
 # Let feed shutdown gracefully by giving it plenty of time to stop.
-RUN sed -i 's/KILL_PROCESS_TIMEOUT = 5/KILL_PROCESS_TIMEOUT = 300/' /sbin/my_init \
-    && grep 'KILL_PROCESS_TIMEOUT = 300' /sbin/my_init
+# Give children processes 5 minutes to timeout
+ENV KILL_PROCESS_TIMEOUT=300
+# Give all other processes (such as those which have been forked) 5 minutes to timeout
+ENV KILL_ALL_PROCESSES_TIMEOUT=300
 
 ENTRYPOINT ["/sbin/my_init", "--quiet", "--", "/sbin/setuser", "nginx", \
     "/feed-ingress", "-nginx-workdir", "/nginx"]

--- a/docker/ingress/logrotate.config
+++ b/docker/ingress/logrotate.config
@@ -1,6 +1,6 @@
 /var/log/nginx/*.log {
-        size 400M
-        rotate 10
+        size 100M
+        rotate 40
         notifempty
         missingok
         create 640 nginx nginx

--- a/docker/ingress/logrotate.cron
+++ b/docker/ingress/logrotate.cron
@@ -1,3 +1,3 @@
 # Do nginx log rotations more often than the default logrotate daily
 # Run logrotate with a low cpu and io priority
-*/5 * * * * root /usr/bin/nice -n 19 /usr/bin/ionice -c3 /usr/sbin/logrotate /etc/logrotate.d/nginx
+* * * * * root /usr/bin/nice -n 19 /usr/bin/ionice -c3 /usr/sbin/logrotate /etc/logrotate.d/nginx


### PR DESCRIPTION
Aggressively rotate access logs to reduce file system cache consumed by
the feed process. If the access log gets too large, it's possible for
kernel allocations to fail in high load situations.

We probably need a better off loading system for access logs here. For
now, this should help prevent all but the worse high load situations (in
which case you can simply disable access logs).