### PR TITLE
Stop logging out the entire Route53 record set on update at Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.2
+* Stop logging out the entire Route53 record set on update at Info in feed-dns: reduce this to Debug,
+  and instead emit the number of records currently in the record set at Info
+
 # v1.2.1
 * Aggressively rotate access logs to avoid excessive file cache usage. This can lead to kernel
   allocation failures when running feed inside a container with a memory limit.

--- a/dns/dns_updater.go
+++ b/dns/dns_updater.go
@@ -192,7 +192,8 @@ func (u *updater) determineManagedRecordSets(rrs []*route53.ResourceRecordSet) [
 func (u *updater) calculateChanges(originalRecords []*route53.ResourceRecordSet,
 	entries controller.IngressEntries) []*route53.Change {
 
-	log.Infof("Current %s records: %v", u.domain, originalRecords)
+	log.Infof("Current %s records: %d", u.domain, len(originalRecords))
+	log.Debugf("Current %s record set: %v", u.domain, originalRecords)
 	log.Debug("Processing ingress update: ", entries)
 
 	hostToIngress, skipped := u.indexByHost(entries)


### PR DESCRIPTION
Bump the entire record set log down to Debug, and add a new Info logging line with the number of current records.