### PR TITLE
Fix wrong output redirection when managing loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.4.1
+* Fix wrong output direction when managing loopback interface using sudo
+
 # v1.4.0
 * Add support for configuring IPVS via [gorb](https://github.com/sky-uk/gorb) with Direct Server Return packet-forwarding method.
   Various flags prefixed with `gorb-` have been added to feed-ingress to customise gorb configuration.

--- a/docker/ingress/build-nginx.sh
+++ b/docker/ingress/build-nginx.sh
@@ -16,7 +16,7 @@ apt-get install --no-install-suggests --no-install-recommends -y \
     sudo
 
 # allow nginx user to manage interfaces and arp configuration
-echo "%nginx ALL=NOPASSWD: /sbin/ip, /bin/echo" >> /etc/sudoers
+echo "%nginx ALL=NOPASSWD: /sbin/ip, /usr/bin/tee" >> /etc/sudoers
 
 echo "--- Downloading nginx and modules"
 mkdir /tmp/nginx

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -265,10 +265,10 @@ func (g *gorb) manageLoopBack(action loopbackAction) error {
 			errorArr = multierror.Append(errorArr, err)
 		}
 
-		_, err = g.command.Execute(fmt.Sprintf("sudo echo %d > %s", arpIgnore, path.Join(g.config.InterfaceProcFsPath, "arp_ignore")))
+		_, err = g.command.Execute(fmt.Sprintf("echo %d | sudo tee %s > /dev/null", arpIgnore, path.Join(g.config.InterfaceProcFsPath, "arp_ignore")))
 		errorArr = multierror.Append(errorArr, err)
 
-		_, err = g.command.Execute(fmt.Sprintf("sudo echo %d > %s", arpAnnounce, path.Join(g.config.InterfaceProcFsPath, "arp_announce")))
+		_, err = g.command.Execute(fmt.Sprintf("echo %d | sudo tee %s > /dev/null", arpAnnounce, path.Join(g.config.InterfaceProcFsPath, "arp_announce")))
 		errorArr = multierror.Append(errorArr, err)
 	}
 
@@ -276,7 +276,7 @@ func (g *gorb) manageLoopBack(action loopbackAction) error {
 }
 
 func (g *gorb) loopbackInterfaceCount(label string, vip string) (int, error) {
-	cmdOutput, err := g.command.Execute(fmt.Sprintf("sudo ip addr show label %s | grep -c %s/32", label, vip))
+	cmdOutput, err := g.command.Execute(fmt.Sprintf("sudo ip addr show label %s | grep -c %s/32 | xargs echo", label, vip))
 	if err != nil {
 		return -1, fmt.Errorf("unable to check whether loopback interface exists for label: %s and vip: %s, error %v", label, vip, err)
 	}

--- a/gorb/gorb_test.go
+++ b/gorb/gorb_test.go
@@ -69,17 +69,17 @@ func mockLoopbackDoesNotExistCommand(mockCommand *fakeCommandRunner, vip string)
 }
 
 func mockLoopbackCheckCommand(mockCommand *fakeCommandRunner, vip string, expectedCount string) {
-	mockCommand.On("Execute", fmt.Sprintf("sudo ip addr show label lo:0 | grep -c %s/32", vip)).Return([]byte(expectedCount), nil)
+	mockCommand.On("Execute", fmt.Sprintf("sudo ip addr show label lo:0 | grep -c %s/32 | xargs echo", vip)).Return([]byte(expectedCount), nil)
 }
 
 func mockDisableArpCommand(mockCommand *fakeCommandRunner) {
-	mockCommand.On("Execute", "sudo echo 1 > /host_ipv4_proc/arp_ignore").Return([]byte{}, nil)
-	mockCommand.On("Execute", "sudo echo 2 > /host_ipv4_proc/arp_announce").Return([]byte{}, nil)
+	mockCommand.On("Execute", "echo 1 | sudo tee /host_ipv4_proc/arp_ignore > /dev/null").Return([]byte{}, nil)
+	mockCommand.On("Execute", "echo 2 | sudo tee /host_ipv4_proc/arp_announce > /dev/null").Return([]byte{}, nil)
 }
 
 func mockEnableArpCommand(mockCommand *fakeCommandRunner) {
-	mockCommand.On("Execute", "sudo echo 0 > /host_ipv4_proc/arp_ignore").Return([]byte{}, nil)
-	mockCommand.On("Execute", "sudo echo 0 > /host_ipv4_proc/arp_announce").Return([]byte{}, nil)
+	mockCommand.On("Execute", "echo 0 | sudo tee /host_ipv4_proc/arp_ignore > /dev/null").Return([]byte{}, nil)
+	mockCommand.On("Execute", "echo 0 | sudo tee /host_ipv4_proc/arp_announce > /dev/null").Return([]byte{}, nil)
 }
 
 func singleServiceConfig(serverURL string) *Config {


### PR DESCRIPTION
Use tee to update the arp configuration instead of echo, as the
redirection output is not done via sudo.
Also ensures the loopback interface check doesn't fail when no loopback
exists for the given VIP.

For #156