### PR TITLE
Reduce logging in controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.4.2
+* Reduce logging each ingress in the controller from Info to Debug, introduced in v1.3.0
+
 # v1.4.1
 * Fix wrong output direction when managing loopback interface using sudo
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -163,7 +163,7 @@ func (c *controller) updateIngresses() error {
 						CreationTimestamp:     ingress.CreationTimestamp.Time,
 					}
 
-					log.Infof("Found ingress to update: %s", ingress.Name)
+					log.Debugf("Found ingress to update: %s", ingress.Name)
 
 					if elbScheme, ok := ingress.Annotations[frontendSchemeAnnotation]; ok {
 						entry.ELbScheme = elbScheme


### PR DESCRIPTION
Logging was introduced in https://github.com/sky-uk/feed/pull/157 and is very spammy.

I've left the actual log as presumably it is quite useful for testing but reduced the level to Debug.