### PR TITLE
Changing the path to python3 for the fake graceful nginx script

### DIFF
--- a/nginx/fake_graceful_nginx.py
+++ b/nginx/fake_graceful_nginx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 import signal
 import sys

--- a/nginx/fake_graceful_nginx.py
+++ b/nginx/fake_graceful_nginx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.6
+#!/usr/bin/env python3.6
 
 import signal
 import sys


### PR DESCRIPTION
This is to change the path to python3.6 from using the absolute path to getting the dynamic path as it does not always live in /usr/bin/.