### PR TITLE
Gorb add HTTP retries using pester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.6.1
+* Moved to using [pester](https://github.com/sethgrid/pester) as an http client
+* Implemented retries on calls to the gorb API
+
 # v1.6.0
 * Enable SSL termination
 Set default ssl path + name file without extension.

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -57,8 +57,6 @@ var (
 	gorbBackendHealthcheckInterval string
 	gorbBackendHealthcheckType     string
 	gorbInterfaceProcFsPath        string
-	gorbHTTPClientTimeout          time.Duration
-	gorbHTTPClientMaxRetries       int
 )
 
 const (
@@ -102,8 +100,6 @@ const (
 	defaultGorbInterfaceProcFsPath           = "/host-ipv4-proc/"
 	defaultGorbBackendHealthcheckInterval    = "1s"
 	defaultGorbBackendHealthcheckType        = "http"
-	defaultGorbHTTPClientTimeout             = time.Second * 2
-	defaultGorbHTTPClientMaxRetries          = 3
 )
 
 func init() {
@@ -222,10 +218,6 @@ func init() {
 		"Define the gorb healthcheck interval for the backend")
 	flag.StringVar(&gorbBackendHealthcheckType, "gorb-backend-healthcheck-type", defaultGorbBackendHealthcheckType,
 		"Define the gorb healthcheck type for the backend. Must be either 'tcp', 'http' or 'none'")
-	flag.DurationVar(&gorbHTTPClientTimeout, "gorb-http-client-timeout", defaultGorbHTTPClientTimeout,
-		"Define the timeout for calls to gorb.")
-	flag.IntVar(&gorbHTTPClientMaxRetries, "gorb-http-client-max-retries", defaultGorbHTTPClientMaxRetries,
-		"Define the number of retries for calls to gorb.")
 
 }
 
@@ -313,8 +305,6 @@ func createIngressUpdaters() ([]controller.Updater, error) {
 			BackendHealthcheckInterval: gorbBackendHealthcheckInterval,
 			BackendHealthcheckType:     gorbBackendHealthcheckType,
 			InterfaceProcFsPath:        gorbInterfaceProcFsPath,
-			HTTPClientTimeout:          gorbHTTPClientTimeout,
-			HTTPClientMaxRetries:       gorbHTTPClientMaxRetries,
 		}
 		gorbUpdater, err := gorb.New(&config)
 		if err != nil {

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -57,6 +57,8 @@ var (
 	gorbBackendHealthcheckInterval string
 	gorbBackendHealthcheckType     string
 	gorbInterfaceProcFsPath        string
+	gorbHTTPClientTimeout          time.Duration
+	gorbHTTPClientMaxRetries       int
 )
 
 const (
@@ -100,6 +102,8 @@ const (
 	defaultGorbInterfaceProcFsPath           = "/host-ipv4-proc/"
 	defaultGorbBackendHealthcheckInterval    = "1s"
 	defaultGorbBackendHealthcheckType        = "http"
+	defaultGorbHTTPClientTimeout             = time.Second * 2
+	defaultGorbHTTPClientMaxRetries          = 3
 )
 
 func init() {
@@ -218,6 +222,10 @@ func init() {
 		"Define the gorb healthcheck interval for the backend")
 	flag.StringVar(&gorbBackendHealthcheckType, "gorb-backend-healthcheck-type", defaultGorbBackendHealthcheckType,
 		"Define the gorb healthcheck type for the backend. Must be either 'tcp', 'http' or 'none'")
+	flag.DurationVar(&gorbHTTPClientTimeout, "gorb-http-client-timeout", defaultGorbHTTPClientTimeout,
+		"Define the timeout for calls to gorb.")
+	flag.IntVar(&gorbHTTPClientMaxRetries, "gorb-http-client-max-retries", defaultGorbHTTPClientMaxRetries,
+		"Define the number of retries for calls to gorb.")
 
 }
 
@@ -305,6 +313,8 @@ func createIngressUpdaters() ([]controller.Updater, error) {
 			BackendHealthcheckInterval: gorbBackendHealthcheckInterval,
 			BackendHealthcheckType:     gorbBackendHealthcheckType,
 			InterfaceProcFsPath:        gorbInterfaceProcFsPath,
+			HTTPClientTimeout:          gorbHTTPClientTimeout,
+			HTTPClientMaxRetries:       gorbHTTPClientMaxRetries,
 		}
 		gorbUpdater, err := gorb.New(&config)
 		if err != nil {

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/hashicorp/go-multierror"
+	"github.com/sethgrid/pester"
 	"github.com/sky-uk/feed/controller"
 )
 
@@ -122,9 +123,9 @@ func New(c *Config) (controller.Updater, error) {
 		backendDefinitions = append(backendDefinitions, backendDefinition)
 	}
 
-	var httpClient = &http.Client{
-		Timeout: time.Second * 5,
-	}
+	httpClient := pester.New()
+	httpClient.Timeout = time.Second * 5
+	httpClient.MaxRetries = 0
 
 	return &gorb{
 		command:    &SimpleCommandRunner{},
@@ -152,7 +153,7 @@ func (c *SimpleCommandRunner) Execute(cmd string) ([]byte, error) {
 type gorb struct {
 	command    CommandRunner
 	config     *Config
-	httpClient *http.Client
+	httpClient *pester.Client
 	backend    []backend
 }
 

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -70,6 +70,8 @@ type Config struct {
 	BackendHealthcheckInterval string
 	BackendHealthcheckType     string
 	InterfaceProcFsPath        string
+	HTTPClientTimeout          time.Duration
+	HTTPClientMaxRetries       int
 }
 
 // Backend defines the backend configuration + service name
@@ -124,8 +126,9 @@ func New(c *Config) (controller.Updater, error) {
 	}
 
 	httpClient := pester.New()
-	httpClient.Timeout = time.Second * 5
-	httpClient.MaxRetries = 0
+	httpClient.Timeout = c.HTTPClientTimeout
+	httpClient.MaxRetries = c.HTTPClientMaxRetries
+	httpClient.Backoff = pester.ExponentialBackoff
 
 	return &gorb{
 		command:    &SimpleCommandRunner{},

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -70,8 +70,6 @@ type Config struct {
 	BackendHealthcheckInterval string
 	BackendHealthcheckType     string
 	InterfaceProcFsPath        string
-	HTTPClientTimeout          time.Duration
-	HTTPClientMaxRetries       int
 }
 
 // Backend defines the backend configuration + service name
@@ -126,9 +124,8 @@ func New(c *Config) (controller.Updater, error) {
 	}
 
 	httpClient := pester.New()
-	httpClient.Timeout = c.HTTPClientTimeout
-	httpClient.MaxRetries = c.HTTPClientMaxRetries
-	httpClient.Backoff = pester.ExponentialBackoff
+	httpClient.Timeout = time.Second * 2
+	httpClient.MaxRetries = 3
 
 	return &gorb{
 		command:    &SimpleCommandRunner{},

--- a/gorb/gorb_test.go
+++ b/gorb/gorb_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"testing"
 
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,7 +18,6 @@ import (
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util/metrics"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 func TestE2E(t *testing.T) {

--- a/gorb/gorb_test.go
+++ b/gorb/gorb_test.go
@@ -9,8 +9,6 @@ import (
 	"net/url"
 	"testing"
 
-	"time"
-
 	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,8 +33,6 @@ const (
 	vipLoadbalancer            = "127.0.0.1"
 	interfaceProcFsPath        = "/host_ipv4_proc/"
 	manageLoopback             = false
-	httpClientTimeout          = time.Second * 1
-	httpClientMaxRetries       = 2
 )
 
 type gorbResponsePrimer struct {
@@ -118,8 +114,6 @@ func newConfig(serverURL string) *Config {
 		BackendHealthcheckInterval: backendHealthcheckInterval,
 		BackendHealthcheckType:     backendHealthcheckType,
 		InterfaceProcFsPath:        interfaceProcFsPath,
-		HTTPClientTimeout:          httpClientTimeout,
-		HTTPClientMaxRetries:       httpClientMaxRetries,
 	}
 }
 
@@ -195,6 +189,7 @@ var _ = Describe("Gorb", func() {
 		It("should return error when status code is not 200", func() {
 			gorbH.responsePrimers = append(gorbH.responsePrimers, gorbResponsePrimer{statusCode: 500})
 			gorbH.responsePrimers = append(gorbH.responsePrimers, gorbResponsePrimer{statusCode: 500})
+			gorbH.responsePrimers = append(gorbH.responsePrimers, gorbResponsePrimer{statusCode: 500})
 
 			g, _ = New(singleServiceConfig(serverURL))
 			err := g.Health()
@@ -264,11 +259,12 @@ var _ = Describe("Gorb", func() {
 			gorbH.responsePrimers = append(gorbH.responsePrimers, gorbResponsePrimer{statusCode: 404})
 			gorbH.responsePrimers = append(gorbH.responsePrimers, gorbResponsePrimer{statusCode: 500})
 			gorbH.responsePrimers = append(gorbH.responsePrimers, gorbResponsePrimer{statusCode: 500})
+			gorbH.responsePrimers = append(gorbH.responsePrimers, gorbResponsePrimer{statusCode: 500})
 
 			g, _ = New(singleServiceConfig(serverURL))
 			err := g.Update(controller.IngressEntries{})
 
-			Expect(len(gorbH.recordedRequests)).To(Equal(3))
+			Expect(len(gorbH.recordedRequests)).To(Equal(4))
 			Expect(err).To(HaveOccurred())
 		})
 

--- a/vendor/github.com/sethgrid/pester/LICENSE.md
+++ b/vendor/github.com/sethgrid/pester/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) SendGrid 2016 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/sethgrid/pester/README.md
+++ b/vendor/github.com/sethgrid/pester/README.md
@@ -1,0 +1,126 @@
+# pester
+
+`pester` wraps Go's standard lib http client to provide several options to increase resiliency in your request. If you experience poor network conditions or requests could experience varied delays, you can now pester the endpoint for data.
+- Send out multiple requests and get the first back (only used for GET calls)
+- Retry on errors
+- Backoff
+
+### Simple Example
+Use `pester` where you would use the http client calls. By default, pester will use a concurrency of 1, and retry the endpoint 3 times with the `DefaultBackoff` strategy of waiting 1 second between retries.
+```go
+/* swap in replacement, just switch
+   http.{Get|Post|PostForm|Head|Do} to
+   pester.{Get|Post|PostForm|Head|Do}
+*/
+resp, err := pester.Get("http://sethammons.com")
+```
+
+### Backoff Strategy
+Provide your own backoff strategy, or use one of the provided built in strategies:
+- `DefaultBackoff`: 1 second
+- `LinearBackoff`: n seconds where n is the retry number
+- `LinearJitterBackoff`: n seconds where n is the retry number, +/- 0-33%
+- `ExponentialBackoff`: n seconds where n is 2^(retry number)
+- `ExponentialJitterBackoff`: n seconds where n is 2^(retry number), +/- 0-33%
+
+```go
+client := pester.New()
+client.Backoff = func(retry int) time.Duration {
+    // set up something dynamic or use a look up table
+    return time.Duration(retry) * time.Minute
+}
+```
+
+### Complete example
+For a complete and working example, see the sample directory.
+`pester` allows you to use a constructor to control:
+- backoff strategy
+- retries
+- concurrency
+- keeping a log for debugging
+```go
+package main
+
+import (
+    "log"
+    "net/http"
+    "strings"
+
+    "github.com/sethgrid/pester"
+)
+
+func main() {
+    log.Println("Starting...")
+
+    { // drop in replacement for http.Get and other client methods
+        resp, err := pester.Get("http://example.com")
+        if err != nil {
+            log.Println("error GETing example.com", err)
+        }
+        defer resp.Body.Close()
+        log.Printf("example.com %s", resp.Status)
+    }
+
+    { // control the resiliency
+        client := pester.New()
+        client.Concurrency = 3
+        client.MaxRetries = 5
+        client.Backoff = pester.ExponentialBackoff
+        client.KeepLog = true
+
+        resp, err := client.Get("http://example.com")
+        if err != nil {
+            log.Println("error GETing example.com", client.LogString())
+        }
+        defer resp.Body.Close()
+        log.Printf("example.com %s", resp.Status)
+    }
+
+    { // use the pester version of http.Client.Do
+        req, err := http.NewRequest("POST", "http://example.com", strings.NewReader("data"))
+        if err != nil {
+            log.Fatal("Unable to create a new http request", err)
+        }
+        resp, err := pester.Do(req)
+        if err != nil {
+            log.Println("error POSTing example.com", err)
+        }
+        defer resp.Body.Close()
+        log.Printf("example.com %s", resp.Status)
+    }
+}
+
+```
+
+### Example Log
+`pester` also allows you to control the resiliency and can optionally log the errors.
+```go
+c := pester.New()
+c.KeepLog = true
+
+nonExistantURL := "http://localhost:9000/foo"
+_, _ = c.Get(nonExistantURL)
+
+fmt.Println(c.LogString())
+/*
+Output:
+
+1432402837 Get [GET] http://localhost:9000/foo request-0 retry-0 error: Get http://localhost:9000/foo: dial tcp 127.0.0.1:9000: connection refused
+1432402838 Get [GET] http://localhost:9000/foo request-0 retry-1 error: Get http://localhost:9000/foo: dial tcp 127.0.0.1:9000: connection refused
+1432402839 Get [GET] http://localhost:9000/foo request-0 retry-2 error: Get http://localhost:9000/foo: dial tcp 127.0.0.1:9000: connection refused
+*/
+```
+
+### Tests
+
+You can run tests in the root directory with `$ go test`. There is a benchmark-like test available with `$ cd benchmarks; go test`.
+You can see `pester` in action with `$ cd sample; go run main.go`.
+
+For watching open file descriptors, you can run `watch "lsof -i -P | grep main"` if you started the app with `go run main.go`.
+I did this for watching for FD leaks. My method was to alter `sample/main.go` to only run one case (`pester.Get with set backoff stategy, concurrency and retries increased`)
+and adding a sleep after the result came back. This let me verify if FDs were getting left open when they should have closed. If you know a better way, let me know!
+I was able to see that FDs are now closing when they should :)
+
+![Are we there yet?](http://butchbellah.com/wp-content/uploads/2012/06/Are-We-There-Yet.jpg)
+
+Are we there yet? Are we there yet? Are we there yet? Are we there yet? ...

--- a/vendor/github.com/sethgrid/pester/pester.go
+++ b/vendor/github.com/sethgrid/pester/pester.go
@@ -1,0 +1,445 @@
+// Package pester provides additional resiliency over the standard http client methods by
+// allowing you to control concurrency, retries, and a backoff strategy.
+package pester
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+//ErrUnexpectedMethod occurs when an http.Client method is unable to be mapped from a calling method in the pester client
+var ErrUnexpectedMethod = errors.New("unexpected client method, must be one of Do, Get, Head, Post, or PostFrom")
+
+// ErrReadingBody happens when we cannot read the body bytes
+var ErrReadingBody = errors.New("error reading body")
+
+// ErrReadingRequestBody happens when we cannot read the request body bytes
+var ErrReadingRequestBody = errors.New("error reading request body")
+
+// Client wraps the http client and exposes all the functionality of the http.Client.
+// Additionally, Client provides pester specific values for handling resiliency.
+type Client struct {
+	// wrap it to provide access to http built ins
+	hc *http.Client
+
+	Transport     http.RoundTripper
+	CheckRedirect func(req *http.Request, via []*http.Request) error
+	Jar           http.CookieJar
+	Timeout       time.Duration
+
+	// pester specific
+	Concurrency int
+	MaxRetries  int
+	Backoff     BackoffStrategy
+	KeepLog     bool
+	LogHook     LogHook
+
+	SuccessReqNum   int
+	SuccessRetryNum int
+
+	wg *sync.WaitGroup
+
+	sync.Mutex
+	ErrLog []ErrEntry
+}
+
+// ErrEntry is used to provide the LogString() data and is populated
+// each time an error happens if KeepLog is set.
+// ErrEntry.Retry is deprecated in favor of ErrEntry.Attempt
+type ErrEntry struct {
+	Time    time.Time
+	Method  string
+	URL     string
+	Verb    string
+	Request int
+	Retry   int
+	Attempt int
+	Err     error
+}
+
+// result simplifies the channel communication for concurrent request handling
+type result struct {
+	resp  *http.Response
+	err   error
+	req   int
+	retry int
+}
+
+// params represents all the params needed to run http client calls and pester errors
+type params struct {
+	method   string
+	verb     string
+	req      *http.Request
+	url      string
+	bodyType string
+	body     io.Reader
+	data     url.Values
+}
+
+var random *rand.Rand
+
+func init() {
+	random = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+// New constructs a new DefaultClient with sensible default values
+func New() *Client {
+	return &Client{
+		Concurrency: DefaultClient.Concurrency,
+		MaxRetries:  DefaultClient.MaxRetries,
+		Backoff:     DefaultClient.Backoff,
+		ErrLog:      DefaultClient.ErrLog,
+		wg:          &sync.WaitGroup{},
+	}
+}
+
+// NewExtendedClient allows you to pass in an http.Client that is previously set up
+// and extends it to have Pester's features of concurrency and retries.
+func NewExtendedClient(hc *http.Client) *Client {
+	c := New()
+	c.hc = hc
+	return c
+}
+
+// LogHook is used to log attempts as they happen. This function is never called,
+// however, if KeepLog is set to true.
+type LogHook func(e ErrEntry)
+
+// BackoffStrategy is used to determine how long a retry request should wait until attempted
+type BackoffStrategy func(retry int) time.Duration
+
+// DefaultClient provides sensible defaults
+var DefaultClient = &Client{Concurrency: 1, MaxRetries: 3, Backoff: DefaultBackoff, ErrLog: []ErrEntry{}}
+
+// DefaultBackoff always returns 1 second
+func DefaultBackoff(_ int) time.Duration {
+	return 1 * time.Second
+}
+
+// ExponentialBackoff returns ever increasing backoffs by a power of 2
+func ExponentialBackoff(i int) time.Duration {
+	return time.Duration(1<<uint(i)) * time.Second
+}
+
+// ExponentialJitterBackoff returns ever increasing backoffs by a power of 2
+// with +/- 0-33% to prevent sychronized reuqests.
+func ExponentialJitterBackoff(i int) time.Duration {
+	return jitter(int(1 << uint(i)))
+}
+
+// LinearBackoff returns increasing durations, each a second longer than the last
+func LinearBackoff(i int) time.Duration {
+	return time.Duration(i) * time.Second
+}
+
+// LinearJitterBackoff returns increasing durations, each a second longer than the last
+// with +/- 0-33% to prevent sychronized reuqests.
+func LinearJitterBackoff(i int) time.Duration {
+	return jitter(i)
+}
+
+// jitter keeps the +/- 0-33% logic in one place
+func jitter(i int) time.Duration {
+	ms := i * 1000
+
+	maxJitter := ms / 3
+
+	// ms ± rand
+	ms += random.Intn(2*maxJitter) - maxJitter
+
+	// a jitter of 0 messes up the time.Tick chan
+	if ms <= 0 {
+		ms = 1
+	}
+
+	return time.Duration(ms) * time.Millisecond
+}
+
+// Wait blocks until all pester requests have returned
+// Probably not that useful outside of testing.
+func (c *Client) Wait() {
+	c.wg.Wait()
+}
+
+// pester provides all the logic of retries, concurrency, backoff, and logging
+func (c *Client) pester(p params) (*http.Response, error) {
+	resultCh := make(chan result)
+	multiplexCh := make(chan result)
+	finishCh := make(chan struct{})
+
+	// track all requests that go out so we can close the late listener routine that closes late incoming response bodies
+	totalSentRequests := &sync.WaitGroup{}
+	totalSentRequests.Add(1)
+	defer totalSentRequests.Done()
+	allRequestsBackCh := make(chan struct{})
+	go func() {
+		totalSentRequests.Wait()
+		close(allRequestsBackCh)
+	}()
+
+	// GET calls should be idempotent and can make use
+	// of concurrency. Other verbs can mutate and should not
+	// make use of the concurrency feature
+	concurrency := c.Concurrency
+	if p.verb != "GET" {
+		concurrency = 1
+	}
+
+	c.Lock()
+	if c.hc == nil {
+		c.hc = &http.Client{}
+		c.hc.Transport = c.Transport
+		c.hc.CheckRedirect = c.CheckRedirect
+		c.hc.Jar = c.Jar
+		c.hc.Timeout = c.Timeout
+	}
+	c.Unlock()
+
+	// re-create the http client so we can leverage the std lib
+	httpClient := http.Client{
+		Transport:     c.hc.Transport,
+		CheckRedirect: c.hc.CheckRedirect,
+		Jar:           c.hc.Jar,
+		Timeout:       c.hc.Timeout,
+	}
+
+	// if we have a request body, we need to save it for later
+	var originalRequestBody []byte
+	var originalBody []byte
+	var err error
+	if p.req != nil && p.req.Body != nil {
+		originalRequestBody, err = ioutil.ReadAll(p.req.Body)
+		if err != nil {
+			return nil, ErrReadingRequestBody
+		}
+		p.req.Body.Close()
+	}
+	if p.body != nil {
+		originalBody, err = ioutil.ReadAll(p.body)
+		if err != nil {
+			return nil, ErrReadingBody
+		}
+	}
+
+	AttemptLimit := c.MaxRetries
+	if AttemptLimit <= 0 {
+		AttemptLimit = 1
+	}
+
+	for req := 0; req < concurrency; req++ {
+		c.wg.Add(1)
+		totalSentRequests.Add(1)
+		go func(n int, p params) {
+			defer c.wg.Done()
+			defer totalSentRequests.Done()
+
+			var err error
+			for i := 1; i <= AttemptLimit; i++ {
+				c.wg.Add(1)
+				defer c.wg.Done()
+				select {
+				case <-finishCh:
+					return
+				default:
+				}
+
+				// rehydrate the body (it is drained each read)
+				if len(originalRequestBody) > 0 {
+					p.req.Body = ioutil.NopCloser(bytes.NewBuffer(originalRequestBody))
+				}
+				if len(originalBody) > 0 {
+					p.body = bytes.NewBuffer(originalBody)
+				}
+
+				var resp *http.Response
+				// route the calls
+				switch p.method {
+				case "Do":
+					resp, err = httpClient.Do(p.req)
+				case "Get":
+					resp, err = httpClient.Get(p.url)
+				case "Head":
+					resp, err = httpClient.Head(p.url)
+				case "Post":
+					resp, err = httpClient.Post(p.url, p.bodyType, p.body)
+				case "PostForm":
+					resp, err = httpClient.PostForm(p.url, p.data)
+				default:
+					err = ErrUnexpectedMethod
+				}
+
+				// Early return if we have a valid result
+				// Only retry (ie, continue the loop) on 5xx status codes
+				if err == nil && resp.StatusCode < 500 {
+					multiplexCh <- result{resp: resp, err: err, req: n, retry: i}
+					return
+				}
+
+				c.log(ErrEntry{
+					Time:    time.Now(),
+					Method:  p.method,
+					Verb:    p.verb,
+					URL:     p.url,
+					Request: n,
+					Retry:   i + 1, // would remove, but would break backward compatibility
+					Attempt: i,
+					Err:     err,
+				})
+
+				// if it is the last iteration, grab the result (which is an error at this point)
+				if i == AttemptLimit {
+					multiplexCh <- result{resp: resp, err: err}
+					return
+				}
+
+				// if we are retrying, we should close this response body to free the fd
+				if resp != nil {
+					resp.Body.Close()
+				}
+
+				// prevent a 0 from causing the tick to block, pass additional microsecond
+				<-time.After(c.Backoff(i) + 1*time.Microsecond)
+			}
+		}(req, p)
+	}
+
+	// spin off the go routine so it can continually listen in on late results and close the response bodies
+	go func() {
+		gotFirstResult := false
+		for {
+			select {
+			case res := <-multiplexCh:
+				if !gotFirstResult {
+					gotFirstResult = true
+					close(finishCh)
+					resultCh <- res
+				} else if res.resp != nil {
+					// we only return one result to the caller; close all other response bodies that come back
+					// drain the body before close as to not prevent keepalive. see https://gist.github.com/mholt/eba0f2cc96658be0f717
+					io.Copy(ioutil.Discard, res.resp.Body)
+					res.resp.Body.Close()
+				}
+			case <-allRequestsBackCh:
+				// don't leave this goroutine running
+				return
+			}
+		}
+	}()
+
+	res := <-resultCh
+	c.Lock()
+	defer c.Unlock()
+	c.SuccessReqNum = res.req
+	c.SuccessRetryNum = res.retry
+	return res.resp, res.err
+
+}
+
+// LogString provides a string representation of the errors the client has seen
+func (c *Client) LogString() string {
+	c.Lock()
+	defer c.Unlock()
+	var res string
+	for _, e := range c.ErrLog {
+		res += c.FormatError(e)
+	}
+	return res
+}
+
+// Format the Error to human readable string
+func (c *Client) FormatError(e ErrEntry) string {
+	return fmt.Sprintf("%d %s [%s] %s request-%d retry-%d error: %s\n",
+		e.Time.Unix(), e.Method, e.Verb, e.URL, e.Request, e.Retry, e.Err)
+}
+
+// LogErrCount is a helper method used primarily for test validation
+func (c *Client) LogErrCount() int {
+	c.Lock()
+	defer c.Unlock()
+	return len(c.ErrLog)
+}
+
+// EmbedHTTPClient allows you to extend an existing Pester client with an
+// underlying http.Client, such as https://godoc.org/golang.org/x/oauth2/google#DefaultClient
+func (c *Client) EmbedHTTPClient(hc *http.Client) {
+	c.hc = hc
+}
+
+func (c *Client) log(e ErrEntry) {
+	if c.KeepLog {
+		c.Lock()
+		defer c.Unlock()
+		c.ErrLog = append(c.ErrLog, e)
+	} else if c.LogHook != nil {
+		// NOTE: There is a possibility that Log Printing hook slows it down.
+		// but the consumer can always do the Job in a go-routine.
+		c.LogHook(e)
+	}
+}
+
+// Do provides the same functionality as http.Client.Do
+func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
+	return c.pester(params{method: "Do", req: req, verb: req.Method, url: req.URL.String()})
+}
+
+// Get provides the same functionality as http.Client.Get
+func (c *Client) Get(url string) (resp *http.Response, err error) {
+	return c.pester(params{method: "Get", url: url, verb: "GET"})
+}
+
+// Head provides the same functionality as http.Client.Head
+func (c *Client) Head(url string) (resp *http.Response, err error) {
+	return c.pester(params{method: "Head", url: url, verb: "HEAD"})
+}
+
+// Post provides the same functionality as http.Client.Post
+func (c *Client) Post(url string, bodyType string, body io.Reader) (resp *http.Response, err error) {
+	return c.pester(params{method: "Post", url: url, bodyType: bodyType, body: body, verb: "POST"})
+}
+
+// PostForm provides the same functionality as http.Client.PostForm
+func (c *Client) PostForm(url string, data url.Values) (resp *http.Response, err error) {
+	return c.pester(params{method: "PostForm", url: url, data: data, verb: "POST"})
+}
+
+////////////////////////////////////////
+// Provide self-constructing variants //
+////////////////////////////////////////
+
+// Do provides the same functionality as http.Client.Do and creates its own constructor
+func Do(req *http.Request) (resp *http.Response, err error) {
+	c := New()
+	return c.Do(req)
+}
+
+// Get provides the same functionality as http.Client.Get and creates its own constructor
+func Get(url string) (resp *http.Response, err error) {
+	c := New()
+	return c.Get(url)
+}
+
+// Head provides the same functionality as http.Client.Head and creates its own constructor
+func Head(url string) (resp *http.Response, err error) {
+	c := New()
+	return c.Head(url)
+}
+
+// Post provides the same functionality as http.Client.Post and creates its own constructor
+func Post(url string, bodyType string, body io.Reader) (resp *http.Response, err error) {
+	c := New()
+	return c.Post(url, bodyType, body)
+}
+
+// PostForm provides the same functionality as http.Client.PostForm and creates its own constructor
+func PostForm(url string, data url.Values) (resp *http.Response, err error) {
+	c := New()
+	return c.PostForm(url, data)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -675,6 +675,12 @@
 			"revisionTime": "2016-04-11T19:08:41Z"
 		},
 		{
+			"checksumSHA1": "0V9YhjDv2UlkQaAbSK41fzlx3JA=",
+			"path": "github.com/sethgrid/pester",
+			"revision": "760f8913c0483b776294e1bee43f1d687527127b",
+			"revisionTime": "2017-11-27T02:50:28Z"
+		},
+		{
 			"checksumSHA1": "GxPD7A0NjMDom1xte0mghkpzr0E=",
 			"path": "github.com/spf13/pflag",
 			"revision": "5ccb023bc27df288a957c5e994cd44fd19619465",


### PR DESCRIPTION
Changing the http client gorb uses to pester which allows us to define retry settings. [Pester](https://github.com/sethgrid/pester) uses the built-in golang http client and adds a wrapper allowing us more functionality when making basic http requests.

Adding two new feed ingress flags:
* gorb-http-client-timeout (default: 2s)
* gorb-http-client-max-retries (default: 3)