### PR TITLE
Nginx upstream max connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.8.0
 * Upgraded to Nginx 1.12.2 and VTS 0.1.15
 * Introduced `sky.uk/backend-max-connections` annotation that sets upstream.max_conns (http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns)
-* Introduced flag to set global value for upstream.max_conns (default: 0 - unlimited)
+* Introduced flag to set global value for upstream.max_conns (default: 1024)
 
 # v1.7.0
 * Add support for [merlin](https://github.com/sky-uk/merlin) frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.8.0
+* Upgraded to Nginx 1.12.2 and VTS 0.1.15
+* Introduced `sky.uk/backend-max-connections` annotation that sets upstream.max_conns (http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns)
+* Introduced flag to set global value for upstream.max_conns (default: 0 - unlimited)
+
 # v1.7.0
 * Add support for [merlin](https://github.com/sky-uk/merlin) frontend
 * Swap to dep from govendor

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -85,6 +85,7 @@ const (
 	defaultNginxBackendKeepalives            = 512
 	defaultNginxBackendTimeoutSeconds        = 60
 	defaultNginxBackendConnectTimeoutSeconds = 1
+	defaultNginxBackendMaxConnections        = 1024
 	defaultNginxLogLevel                     = "warn"
 	defaultNginxServerNamesHashBucketSize    = unset
 	defaultNginxServerNamesHashMaxSize       = unset
@@ -163,6 +164,9 @@ func init() {
 	flag.IntVar(&nginxConfig.BackendConnectTimeoutSeconds, "nginx-backend-connect-timeout-seconds",
 		defaultNginxBackendConnectTimeoutSeconds,
 		"Connect timeout to backend services.")
+	flag.IntVar(&controllerConfig.DefaultBackendMaxConnections, "nginx-default-backend-max-connections",
+		defaultNginxBackendMaxConnections,
+		"Maximum connections to backends. Can be overridden per ingress with the sky.uk/backend-max-connections annotation.")
 	flag.StringVar(&nginxConfig.LogLevel, "nginx-loglevel", defaultNginxLogLevel,
 		"Log level for nginx. See http://nginx.org/en/docs/ngx_core_module.html#error_log for levels.")
 	flag.IntVar(&nginxConfig.ServerNamesHashBucketSize, "nginx-server-names-hash-bucket-size", defaultNginxServerNamesHashBucketSize,

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -166,7 +166,7 @@ func init() {
 		"Connect timeout to backend services.")
 	flag.IntVar(&controllerConfig.DefaultBackendMaxConnections, "nginx-default-backend-max-connections",
 		defaultNginxBackendMaxConnections,
-		"Maximum connections to backends. Can be overridden per ingress with the sky.uk/backend-max-connections annotation.")
+		"Maximum number of connections to a single backend. Can be overridden per ingress with the sky.uk/backend-max-connections annotation.")
 	flag.StringVar(&nginxConfig.LogLevel, "nginx-loglevel", defaultNginxLogLevel,
 		"Log level for nginx. See http://nginx.org/en/docs/ngx_core_module.html#error_log for levels.")
 	flag.IntVar(&nginxConfig.ServerNamesHashBucketSize, "nginx-server-names-hash-bucket-size", defaultNginxServerNamesHashBucketSize,

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -32,6 +32,8 @@ type IngressEntry struct {
 	StripPaths bool
 	// BackendTimeoutSeconds backend timeout
 	BackendTimeoutSeconds int
+	// BackendMaxConnections maximum backend connections
+	BackendMaxConnections int
 	// Ingress creation time
 	CreationTimestamp time.Time
 }

--- a/docker/ingress/Dockerfile
+++ b/docker/ingress/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
-ENV NGINX_VERSION 1.10.2
-ENV NGINX_SHA256 1045ac4987a396e2fa5d0011daf8987b612dd2f05181b67507da68cbe7d765c2
-ENV VTS_VERSION 0.1.10
-ENV VTS_SHA256 c6f3733e9ff84bfcdc6bfb07e1baf59e72c4e272f06964dd0ed3a1bdc93fa0ca
+ENV NGINX_VERSION 1.12.2
+ENV NGINX_SHA256 305f379da1d5fb5aefa79e45c829852ca6983c7cd2a79328f8e084a324cf0416
+ENV VTS_VERSION 0.1.15
+ENV VTS_SHA256 5112a054b1b1edb4c0042a9a840ef45f22abb3c05c68174e28ebf483164fb7e1
 
 COPY build-nginx.sh /tmp
 RUN /bin/bash /tmp/build-nginx.sh

--- a/docker/ingress/build-nginx.sh
+++ b/docker/ingress/build-nginx.sh
@@ -62,7 +62,7 @@ echo "--- Configuring nginx"
     --with-http_v2_module \
     --with-ipv6 \
     --with-debug \
-    --add-module=/tmp/nginx/nginx-module-vts-0.1.10\
+    --add-module=/tmp/nginx/nginx-module-vts-${VTS_VERSION}\
     --with-http_ssl_module
 
 echo "--- Building nginx"

--- a/examples/ingress.yml
+++ b/examples/ingress.yml
@@ -15,7 +15,10 @@ metadata:
     sky.uk/strip-path: "true"
 
     # Max timeout for requests.
-    sky.uk/backend-timeout-seconds: 20
+    sky.uk/backend-timeout-seconds: "20"
+
+    # Maximum backend connections (http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns)
+    sky.uk/backend-max-connections: "512"
 spec:
   rules:
   - host: example.bskyb.com

--- a/examples/ingress.yml
+++ b/examples/ingress.yml
@@ -14,10 +14,10 @@ metadata:
     # Strip the path from the path passed to the backend service.
     sky.uk/strip-path: "true"
 
-    # Max timeout for requests.
+    # Max timeout for requests. Values must be quoted or they'll be silently dropped by kubectl.
     sky.uk/backend-timeout-seconds: "20"
 
-    # Maximum backend connections (http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns)
+    # Maximum backend connections (http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns). Values must be quoted or they'll be silently dropped by kubectl.
     sky.uk/backend-max-connections: "512"
 spec:
   rules:

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -123,8 +123,9 @@ type server struct {
 }
 
 type upstream struct {
-	ID     string
-	Server string
+	ID             string
+	Server         string
+	MaxConnections int
 }
 
 type location struct {
@@ -401,8 +402,9 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 
 	for _, ingressEntry := range entries {
 		upstream := &upstream{
-			ID:     upstreamID(ingressEntry),
-			Server: fmt.Sprintf("%s:%d", ingressEntry.ServiceAddress, ingressEntry.ServicePort),
+			ID:             upstreamID(ingressEntry),
+			Server:         fmt.Sprintf("%s:%d", ingressEntry.ServiceAddress, ingressEntry.ServicePort),
+			MaxConnections: ingressEntry.BackendMaxConnections,
 		}
 		idToUpstream[upstream.ID] = upstream
 	}

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -91,10 +91,10 @@ http {
     # Start ingresses
     {{- $keepalive := .BackendKeepalives }}
     {{- $proxyprotocol := .ProxyProtocol }}
-    
+
 {{- range $upstream := .Upstreams }}
     upstream {{ $upstream.ID }} {
-        server {{ $upstream.Server }};
+        server {{ $upstream.Server }} max_conns={{ $upstream.MaxConnections }};
         keepalive {{ $keepalive }};
     }
 {{ end }}
@@ -124,7 +124,7 @@ http {
 {{- end }}
 
         # disable any limits to avoid HTTP 413 for large uploads
-        client_max_body_size 0; 
+        client_max_body_size 0;
 
         {{- range $location := $entry.Locations }}
 

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -387,15 +387,16 @@ func TestNginxIngressEntries(t *testing.T) {
 					Allow:                 []string{"10.86.0.0/16"},
 					StripPaths:            false,
 					BackendTimeoutSeconds: 10,
+					BackendMaxConnections: 1024,
 				},
 			},
 			[]string{
 				"    upstream core.anotherservice.6060 {\n" +
-					"        server anotherservice:6060;\n" +
+					"        server anotherservice:6060 max_conns=1024;\n" +
 					"        keepalive 1024;\n" +
 					"    }",
 				"    upstream core.service.8080 {\n" +
-					"        server service:8080;\n" +
+					"        server service:8080 max_conns=0;\n" +
 					"        keepalive 1024;\n" +
 					"    }",
 			},
@@ -671,7 +672,7 @@ func TestNginxIngressEntries(t *testing.T) {
 
 			[]string{
 				"    upstream core.service.9090 {\n" +
-					"        server service:9090;\n" +
+					"        server service:9090 max_conns=0;\n" +
 					"        keepalive 1024;\n" +
 					"    }",
 			},
@@ -965,7 +966,7 @@ func TestRateLimitedForUpdates(t *testing.T) {
 		{
 			Host:           "chris.com",
 			Path:           "/path",
-			ServiceAddress: "something different",
+			ServiceAddress: "somethingdifferent",
 			ServicePort:    9090,
 		},
 	}


### PR DESCRIPTION
The problem right now is there is no cap no connections per upstream. So if a service is slow, nginx will respond by actually increasing the number of connections - thus making things worse.