### PR TITLE
Fix feed releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script: make travis
 
 deploy:
 - provider: script
+  skip_cleanup: true
   script: make release
   on:
     tags: true


### PR DESCRIPTION
Need to skip cleanup, otherwise vendor gets nuked.