### PR TITLE
Configure memory allocated to vhost stats module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.9.1
+* Introduced flag to set the amount of memory allocated to the vhost statistics module (default: 1 MiB)
+
 # v1.9.0
 * Add ability to specify health checks for merlin frontends.
 

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -46,6 +46,7 @@ var (
 	nginxLogHeaders                cmd.CommaSeparatedValues
 	nginxTrustedFrontends          cmd.CommaSeparatedValues
 	nginxSSLPath                   string
+	nginxVhostStatsSharedMemory    int
 	legacyBackendKeepaliveSeconds  int
 	registrationFrontendType       string
 	gorbIngressInstanceIP          string
@@ -96,6 +97,7 @@ const (
 	defaultNginxProxyProtocol                = false
 	defaultNginxUpdatePeriod                 = time.Second * 30
 	defaultNginxSSLPath                      = "/etc/ssl/default-ssl/default-ssl"
+	defaultNginxVhostStatsSharedMemory       = 1
 	defaultElbLabelValue                     = ""
 	defaultDrainDelay                        = time.Second * 60
 	defaultTargetGroupDeregistrationDelay    = time.Second * 300
@@ -198,6 +200,8 @@ func init() {
 			"This will typically be the ELB subnet.")
 	flag.StringVar(&nginxSSLPath, "ssl-path", defaultNginxSSLPath,
 		"Set default ssl path + name file without extension.  Feed expects two files: one ending in .crt (the CA) and the other in .key (the private key).")
+	flag.IntVar(&nginxVhostStatsSharedMemory, "vhost-stats-shared-memory", defaultNginxVhostStatsSharedMemory,
+		"Memory (in MiB) which should be allocated for use by the vhost statistics module")
 
 	// elb/alb flags
 	flag.StringVar(&region, "region", defaultRegion,
@@ -316,6 +320,7 @@ func createIngressUpdaters() ([]controller.Updater, error) {
 	nginxConfig.SSLPath = nginxSSLPath
 	nginxConfig.TrustedFrontends = nginxTrustedFrontends
 	nginxConfig.LogHeaders = nginxLogHeaders
+	nginxConfig.VhostStatsSharedMemory = nginxVhostStatsSharedMemory
 	nginxUpdater := nginx.New(nginxConfig)
 
 	updaters := []controller.Updater{nginxUpdater}

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -200,7 +200,7 @@ func init() {
 			"This will typically be the ELB subnet.")
 	flag.StringVar(&nginxSSLPath, "ssl-path", defaultNginxSSLPath,
 		"Set default ssl path + name file without extension.  Feed expects two files: one ending in .crt (the CA) and the other in .key (the private key).")
-	flag.IntVar(&nginxVhostStatsSharedMemory, "vhost-stats-shared-memory", defaultNginxVhostStatsSharedMemory,
+	flag.IntVar(&nginxVhostStatsSharedMemory, "nginx-vhost-stats-shared-memory", defaultNginxVhostStatsSharedMemory,
 		"Memory (in MiB) which should be allocated for use by the vhost statistics module")
 
 	// elb/alb flags

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -58,7 +58,7 @@ type Conf struct {
 	AccessLogHeaders             string
 	UpdatePeriod                 time.Duration
 	SSLPath                      string
-	VhostStatsSharedMemory		 int
+	VhostStatsSharedMemory       int
 }
 
 type nginx struct {

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -58,6 +58,7 @@ type Conf struct {
 	AccessLogHeaders             string
 	UpdatePeriod                 time.Duration
 	SSLPath                      string
+	VhostStatsSharedMemory		 int
 }
 
 type nginx struct {

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -19,7 +19,7 @@ http {
     default_type text/html;
 
     # Track extended virtual host stats.
-    vhost_traffic_status_zone;
+    vhost_traffic_status_zone shared:vhost_traffic_status:{{ .VhostStatsSharedMemory }}m;
 
     # Server names hash bucket sizes. Set based on nginx log messages.
     {{ if gt .ServerNamesHashBucketSize 0 }}server_names_hash_bucket_size {{ .ServerNamesHashBucketSize }};{{ end }}

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -45,6 +45,7 @@ func newConf(tmpDir string, binary string) Conf {
 		ServerNamesHashMaxSize:       -1,
 		ServerNamesHashBucketSize:    -1,
 		UpdatePeriod:                 time.Second,
+		VhostStatsSharedMemory:       1,
 	}
 }
 
@@ -317,6 +318,13 @@ func TestNginxConfig(t *testing.T) {
 			sslEndpointConf,
 			[]string{
 				"listen 443 ssl default_server;",
+			},
+		},
+		{
+			"Vhost stats module has 1 MiB of shared memory",
+			defaultConf,
+			[]string{
+				"vhost_traffic_status_zone shared:vhost_traffic_status:1m",
 			},
 		},
 	}


### PR DESCRIPTION
In some cases, this may need to be set to a value higher than the
default of 1 MiB, and is now configurable through the
`vhost-stats-shared-memory` flag. Default value is 1 MiB.