### PR TITLE
Attach to https in merlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v1.9.3
 * Attach to https in addition to http for merlin.
+* Fix merlin deregistration, which was failing due to long lived connections getting killed.
 
 # v1.9.2
 * Bug fix for merlin attacher - fix netlink and capabilities for feed-ingress.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.9.3
+* Attach to https in addition to http for merlin.
+
 # v1.9.2
 * Bug fix for merlin attacher - fix netlink and capabilities for feed-ingress.
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,11 +21,6 @@
   revision = "5bd2802263f21d8788851d5305584c82a5c75d7e"
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  revision = "6d9ae300aaf85d6acd2e5424081c7fcddb21dab8"
-
-[[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -228,6 +223,12 @@
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/onrik/logrus"
+  packages = ["filename"]
+  revision = "6a64e23a4923a8d0d4db2806dcf3e55af1e48f61"
+
+[[projects]]
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -295,7 +296,6 @@
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "log",
     "model"
   ]
   revision = "a3a8fe85f2579bcfec713dbfacbdd0797a792f3a"
@@ -309,6 +309,11 @@
   name = "github.com/sethgrid/pester"
   packages = ["."]
   revision = "760f8913c0483b776294e1bee43f1d687527127b"
+
+[[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "6d9ae300aaf85d6acd2e5424081c7fcddb21dab8"
 
 [[projects]]
   name = "github.com/sky-uk/merlin"
@@ -613,6 +618,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "16569a087390fa911eb364c26d60f93d1b9889eff1cbd977e94e242816e4f464"
+  inputs-digest = "8a7e22c97b367f32e922692010ce85120547c9b46b841b643257d6359ab66826"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,3 +28,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/onrik/logrus"

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -11,11 +11,11 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	aws_alb "github.com/aws/aws-sdk-go/service/elbv2"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util"
 )

--- a/cmd/feed-dns/main.go
+++ b/cmd/feed-dns/main.go
@@ -7,7 +7,7 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/dns"
 	"github.com/sky-uk/feed/dns/adapter"

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -256,7 +256,7 @@ func init() {
 	flag.StringVar(&merlinEndpoint, "merlin-endpoint", "",
 		"Merlin gRPC endpoint to connect to. Expected format is scheme://authority/endpoint_name (see "+
 			"https://github.com/grpc/grpc/blob/master/doc/naming.md). Will load balance between all available servers.")
-	flag.DurationVar(&merlinRequestTimeout, "merlin-request-timeout", time.Second * 10,
+	flag.DurationVar(&merlinRequestTimeout, "merlin-request-timeout", time.Second*10,
 		"Timeout for any requests to merlin.")
 	flag.StringVar(&merlinServiceID, "merlin-service-id", "", "Merlin http virtual service ID to attach to.")
 	flag.StringVar(&merlinHTTPSServiceID, "merlin-https-service-id", "", "Merlin https virtual service ID to attach to.")

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/alb"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/elb"

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -15,7 +15,7 @@ import (
 
 	"errors"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/k8s"
 	"github.com/sky-uk/feed/util"
 	"k8s.io/client-go/pkg/api/v1"

--- a/dns/dns_updater.go
+++ b/dns/dns_updater.go
@@ -5,8 +5,8 @@ import (
 
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/service/route53"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/dns/adapter"
 	"github.com/sky-uk/feed/dns/r53"

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -12,11 +12,11 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	aws_elb "github.com/aws/aws-sdk-go/service/elb"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util"
 )

--- a/examples/feed-ingress-deployment-merlin.yml
+++ b/examples/feed-ingress-deployment-merlin.yml
@@ -67,6 +67,7 @@ spec:
         args:
         # Ingress nginx port that frontend will direct traffic towards.
         - -ingress-port=80
+        - -ingress-https-port=443
 
         # Health port on nginx, used by frontend to determine health.
         - -ingress-health-port=8081
@@ -97,14 +98,12 @@ spec:
         # gRPC endpoint
         - -merlin-endpoint=dns:///merlin-servers
 
-        # Virtual Service ID to attach to
+        # Virtual Service IDs to attach to
         - -merlin-service-id=my-virtual-service
+        - -merlin-https-service-id=my-https-virtual-service
 
         # Real server IP to associate with virtual service - the IP of the ingress node.
         - -merlin-instance-ip=$(INSTANCEIP)
-
-        # Real server port to associate with virtual service - the port of nginx.
-        - -merlin-instance-port=80
 
         # Forward method that IPVS should use - pick route, masq, or tunnel.
         - -merlin-forward-method=route

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -22,9 +22,9 @@ import (
 
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/hashicorp/go-multierror"
 	"github.com/sethgrid/pester"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 )
 

--- a/gorb/gorb_test.go
+++ b/gorb/gorb_test.go
@@ -9,10 +9,10 @@ import (
 	"net/url"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util/metrics"
 	"github.com/stretchr/testify/mock"

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -12,7 +12,7 @@ import (
 
 	"errors"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"

--- a/k8s/watcher.go
+++ b/k8s/watcher.go
@@ -5,7 +5,7 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Watcher provides channels for receiving updates. It tries its best to run forever, retrying

--- a/merlin/merlin.go
+++ b/merlin/merlin.go
@@ -10,7 +10,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/prometheus/common/log"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/merlin/types"
 	"google.golang.org/grpc"

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -20,7 +20,7 @@ import (
 
 	"sort"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util"
 )

--- a/nginx/nginx_metrics.go
+++ b/nginx/nginx_metrics.go
@@ -11,8 +11,8 @@ import (
 
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/util/metrics"
 )
 

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -12,8 +12,9 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/onrik/logrus/filename"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/util/metrics"
 )
 
@@ -105,6 +106,9 @@ func ConfigureLogging(debug bool) {
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	}
+	filenameHook := filename.NewHook()
+	filenameHook.Field = "source"
+	log.AddHook(filenameHook)
 }
 
 // ConfigureMetrics sets up metrics pushing and default labels. This must be called before any metrics

--- a/util/metrics/prometheus.go
+++ b/util/metrics/prometheus.go
@@ -3,8 +3,8 @@ package metrics
 import (
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
Also some small improvements:
* Expose the merlin request timeout, so it's easy to change if necessary
* Make deregistration more resilient, which could fail due to the long lived grpc connection getting killed. Instead, create and close connections on demand.