### PR TITLE
Add 'empty' or 'None' service name check while generating upstream entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
 *.iml
+*.ipr
+*.iws
 *.swp
 build
 vendor

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -402,7 +402,7 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 	idToUpstream := make(map[string]*upstream)
 
 	for _, ingressEntry := range entries {
-		if validUpstreamEntry(ingressEntry)  {
+		if validUpstreamEntry(ingressEntry) {
 			upstream := &upstream{
 				ID:             upstreamID(ingressEntry),
 				Server:         fmt.Sprintf("%s:%d", ingressEntry.ServiceAddress, ingressEntry.ServicePort),
@@ -421,8 +421,8 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 	return sortedUpstreams
 }
 
-func validUpstreamEntry (e controller.IngressEntry) bool {
-	return 	e.ServiceAddress != "None" && e.ServiceAddress != ""
+func validUpstreamEntry(e controller.IngressEntry) bool {
+	return e.ServiceAddress != "None" && e.ServiceAddress != ""
 }
 
 func upstreamID(e controller.IngressEntry) string {

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -402,12 +402,14 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 	idToUpstream := make(map[string]*upstream)
 
 	for _, ingressEntry := range entries {
-		upstream := &upstream{
-			ID:             upstreamID(ingressEntry),
-			Server:         fmt.Sprintf("%s:%d", ingressEntry.ServiceAddress, ingressEntry.ServicePort),
-			MaxConnections: ingressEntry.BackendMaxConnections,
+		if validUpstreamEntry(ingressEntry)  {
+			upstream := &upstream{
+				ID:             upstreamID(ingressEntry),
+				Server:         fmt.Sprintf("%s:%d", ingressEntry.ServiceAddress, ingressEntry.ServicePort),
+				MaxConnections: ingressEntry.BackendMaxConnections,
+			}
+			idToUpstream[upstream.ID] = upstream
 		}
-		idToUpstream[upstream.ID] = upstream
 	}
 
 	var sortedUpstreams []*upstream
@@ -417,6 +419,10 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 
 	sort.Sort(upstreams(sortedUpstreams))
 	return sortedUpstreams
+}
+
+func validUpstreamEntry (e controller.IngressEntry) bool {
+	return 	e.ServiceAddress != "None" && e.ServiceAddress != ""
 }
 
 func upstreamID(e controller.IngressEntry) string {

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -924,7 +924,6 @@ func TestServiceAddressAsNoneOrEmptyShouldNotHaveUpstreamEntries(t *testing.T) {
 	assert.NoError(err)
 	configContents := string(config)
 
-
 	assertConfigEntries(t, t.Name(), "upstream", `(?sU)(    upstream.+\n    })`, nil, configContents)
 
 	if t.Failed() {


### PR DESCRIPTION
https://github.com/sky-uk/core-infrastructure/issues/2421