### PR TITLE
Adding internal and internet facing hostnames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
 *.iml
 *.swp
+*.ipr
+*.iws
 build
 vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.10.1
+* Added `merlin-internal-hostname` and `merlin-internet-facing-hostname` flags for setting Merlin ingress status,
+replacing the `merlin-internet-facing-vip` flag
+* Included extra testing around ingress validation
+
 # v1.10.0
 * Added `k8s/status` library for setting ingress status
 * ELB and Merlin updaters set relevant ingress status

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ label to an ingress. The updater will then set the ingress status to the elb's D
 
 #### Merlin
 
-The Merlin updater is currently unable to auto-discover all hosted vips (virtual ip addresses) on a Merlin server;
-instead the status updater supports two different loadbalancer types: `internal` and `internet-facing`. These two vips
-are set using the `merlin-vip` and `merlin-internet-facing-vip` flags respectively.
+The Merlin updater is currently unable to auto-discover all hosted loadbalancers on a Merlin server; instead the status
+updater supports two different types: `internal` and `internet-facing`. These two loadbalancers are set using the
+`merlin-internal-hostname` and `merlin-internet-facing-hostname` flags respectively.
 
 An ingress can select which loadbalancer it wants to be associated with by setting the `sky.uk/frontend-scheme`
 annotation to either `internal` or `internet-facing`.

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -351,6 +351,12 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 			nil,
 		},
 		{
+			"ingress with 'None' as service IP",
+			createDefaultIngresses(),
+			createServiceFixture(ingressSvcName, ingressNamespace, "None"),
+			nil,
+		},
+		{
 			"ingress with default allow",
 			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, "MISSING", stripPath, backendTimeout, frontendElbSchemeAnnotation, defaultMaxConnections),
 			createDefaultServices(),

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -50,6 +50,9 @@ func (e IngressEntry) validate() error {
 	if e.ServiceAddress == "" {
 		return errors.New("missing service address")
 	}
+	if e.ServiceAddress == "None" {
+		return errors.New("service address is set to 'None'")
+	}
 	if e.ServicePort == 0 {
 		return errors.New("missing service port")
 	}

--- a/k8s/status/status.go
+++ b/k8s/status/status.go
@@ -44,7 +44,7 @@ func Update(ingresses controller.IngressEntries, lbs map[string]v1.LoadBalancerS
 	}
 
 	if len(failedIngresses) > 0 {
-		return fmt.Errorf("Failed to update ingresses: %s", failedIngresses)
+		return fmt.Errorf("failed to update ingresses: %s", failedIngresses)
 	}
 	return nil
 }

--- a/k8s/status/status_test.go
+++ b/k8s/status/status_test.go
@@ -224,7 +224,7 @@ func TestUpdateFails(t *testing.T) {
 	err := Update(ingresses, lbs, client)
 
 	assert.Error(err)
-	assert.EqualError(err, "Failed to update ingresses: [test]")
+	assert.EqualError(err, "failed to update ingresses: [test]")
 }
 
 func TestUpdateDoesNotRunWithNoChange(t *testing.T) {

--- a/merlin/status/status.go
+++ b/merlin/status/status.go
@@ -18,17 +18,17 @@ const (
 
 // Config for creating a new Merlin status updater.
 type Config struct {
-	InternalVIP       string
-	InternetFacingVIP string
-	KubernetesClient  k8s.Client
+	InternalHostname       string
+	InternetFacingHostname string
+	KubernetesClient       k8s.Client
 }
 
 // New creates a new Merlin frontend status updater.
 func New(conf Config) (controller.Updater, error) {
 	return &status{
-		vips: map[string]string{
-			internalLabelValue:       conf.InternalVIP,
-			internetFacingLabelValue: conf.InternetFacingVIP,
+		cnames: map[string]string{
+			internalLabelValue:       conf.InternalHostname,
+			internetFacingLabelValue: conf.InternetFacingHostname,
 		},
 		loadBalancers:    make(map[string]v1.LoadBalancerStatus),
 		kubernetesClient: conf.KubernetesClient,
@@ -36,16 +36,16 @@ func New(conf Config) (controller.Updater, error) {
 }
 
 type status struct {
-	vips             map[string]string
+	cnames           map[string]string
 	loadBalancers    map[string]v1.LoadBalancerStatus
 	kubernetesClient k8s.Client
 }
 
 // Start generates loadBalancer statuses from valid vips.
 func (s *status) Start() error {
-	for lbLabel, vip := range s.vips {
-		if vip != "" {
-			s.loadBalancers[lbLabel] = k8s_status.GenerateLoadBalancerStatus([]string{vip})
+	for lbLabel, cname := range s.cnames {
+		if cname != "" {
+			s.loadBalancers[lbLabel] = k8s_status.GenerateLoadBalancerStatus([]string{cname})
 		}
 	}
 	return nil


### PR DESCRIPTION
Due to merlin using a cname for all DNS entries rather than a single ip
address, we need to supply both the internal and internet facing
hostnames as the ingress status. This will then allow external-dns to
create a cname from the ingress hostname to this relevant 'ingress'
hostname.