### PR TITLE
Added ignore for 'None' cluster IP while updating nginx config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
 *.iml
 *.swp
+*.ipr
+*.iws
 build
 vendor

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -351,6 +351,12 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 			nil,
 		},
 		{
+			"ingress with 'None' as service IP",
+			createDefaultIngresses(),
+			createServiceFixture(ingressSvcName, ingressNamespace, "None"),
+			nil,
+		},
+		{
 			"ingress with default allow",
 			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, "MISSING", stripPath, backendTimeout, frontendElbSchemeAnnotation, defaultMaxConnections),
 			createDefaultServices(),

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -50,6 +50,9 @@ func (e IngressEntry) validate() error {
 	if e.ServiceAddress == "" {
 		return errors.New("missing service address")
 	}
+	if e.ServiceAddress == "None" {
+		return errors.New("missing service address")
+	}
 	if e.ServicePort == 0 {
 		return errors.New("missing service port")
 	}


### PR DESCRIPTION
fixes: https://github.com/sky-uk/core-infrastructure/issues/2421