### PR TITLE
Fix update ingress bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.10.2
+* Bug fix for k8s/status updater where feed would exit the update loop if any ingress was 'unchanged'
+
 # v1.10.1
 * Added `merlin-internal-hostname` and `merlin-internet-facing-hostname` flags for setting Merlin ingress status,
 replacing the `merlin-internet-facing-vip` flag

--- a/k8s/status/status.go
+++ b/k8s/status/status.go
@@ -32,7 +32,7 @@ func Update(ingresses controller.IngressEntries, lbs map[string]v1.LoadBalancerS
 	for _, ingress := range ingresses {
 		if lb, ok := lbs[ingress.LbScheme]; ok {
 			if statusUnchanged(ingress.Ingress.Status.LoadBalancer.Ingress, lb.Ingress) {
-				return nil
+				continue
 			}
 
 			ingress.Ingress.Status.LoadBalancer.Ingress = lb.Ingress


### PR DESCRIPTION
This is to fix a bug where feed will quit the update ingress loop if
any status is 'unchanged' causing sporadic ingresses to be updated
or left unchanged.