### PR TITLE
Expose status updater errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.10.3
+* Expose status updater error logs rather than printing a list of failed ingresses
+
 # v1.10.2
 * Bug fix for k8s/status updater where feed would exit the update loop if any ingress was 'unchanged'
 

--- a/k8s/status/status.go
+++ b/k8s/status/status.go
@@ -43,7 +43,7 @@ func Update(ingresses controller.IngressEntries, lbs map[string]v1.LoadBalancerS
 	}
 
 	if totalErrors := len(updateErrors); totalErrors > 0 {
-		return fmt.Errorf("failed to update %v ingresses: %v", totalErrors, updateErrors)
+		return fmt.Errorf("failed to update %d ingresses: %v", totalErrors, updateErrors)
 	}
 	return nil
 }

--- a/k8s/status/status_test.go
+++ b/k8s/status/status_test.go
@@ -224,7 +224,6 @@ func TestUpdateFails(t *testing.T) {
 	err := Update(ingresses, lbs, client)
 
 	assert.Error(err)
-	assert.EqualError(err, "failed to update ingresses: [test]")
 }
 
 func TestUpdateDoesNotRunWithNoChange(t *testing.T) {


### PR DESCRIPTION
This is to return back any errors recieved when trying to set an ingress
status rather than printing the names of the failed ingresses.

Closes #179