### PR TITLE
Enable overriding proxy buffer values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.1
+  - 1.11.1
 
 before_install:
   - sudo add-apt-repository -y ppa:jonathonf/python-3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # v1.11.3
 * Enable overriding proxy buffer values. Defaults to `proxy_buffer_size 16k` and `proxy_buffers 4 16k`
 Can be overridden with relevant annotations
-* The values overridden by the annotations are capped at a permissible max `proxy_buffer_size 32k` and `proxy_buffers 8 32k`  
+* The values overridden by the annotations are capped at a permissible max `proxy_buffer_size 32k` and `proxy_buffers 8 32k`
+  
 # v1.11.2
 * Update nginx-opentracing version for bug fix to proxy headers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.11.3
+* Enable overriding proxy buffer values. Defaults to `proxy_buffer_size 16k` and `proxy_buffers 4 16k`
+Can be overridden with relevant annotations
+* The values overridden by the annotations are capped at a permissible max `proxy_buffer_size 32k` and `proxy_buffers 8 32k`  
 # v1.11.2
 * Update nginx-opentracing version for bug fix to proxy headers
 

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -84,7 +84,7 @@ func (a *alb) Update(controller.IngressEntries) error {
 	defer func() { a.readyForHealthCheck.Set(true) }()
 
 	if !a.initialised.done {
-		log.Info("Attaching to ALB target groups: %v", a.targetGroupNames)
+		log.Infof("Attaching to ALB target groups: %v", a.targetGroupNames)
 		if err := a.attachToFrontEnds(); err != nil {
 			return err
 		}

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -6,9 +6,7 @@ package alb
 import (
 	"errors"
 	"fmt"
-
 	"sync"
-
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,8 +36,8 @@ func New(region string, targetGroupNames []string, targetGroupDeregistrationDela
 		awsALB:                         aws_alb.New(session),
 		targetGroupNames:               targetGroupNames,
 		targetGroupDeregistrationDelay: targetGroupDeregistrationDelay,
-		region:      region,
-		initialised: initialised{},
+		region:                         region,
+		initialised:                    initialised{},
 	}, nil
 }
 

--- a/alb/alb_test.go
+++ b/alb/alb_test.go
@@ -1,8 +1,6 @@
 package alb
 
 import (
-	//"errors"
-	//"fmt"
 	"errors"
 	"testing"
 	"time"

--- a/alb/alb_test.go
+++ b/alb/alb_test.go
@@ -3,10 +3,8 @@ package alb
 import (
 	//"errors"
 	//"fmt"
-	"testing"
-
 	"errors"
-
+	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/cmd/feed-dns/main.go
+++ b/cmd/feed-dns/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"flag"
-
 	"os"
-
 	"time"
 
 	log "github.com/sirupsen/logrus"

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -98,6 +98,8 @@ const (
 	defaultNginxBackendTimeoutSeconds        = 60
 	defaultNginxBackendConnectTimeoutSeconds = 1
 	defaultNginxBackendMaxConnections        = 1024
+	defaultNginxProxyBufferSize              = 16
+	defaultNginxProxyBufferBlocks            = 4
 	defaultNginxLogLevel                     = "warn"
 	defaultNginxServerNamesHashBucketSize    = unset
 	defaultNginxServerNamesHashMaxSize       = unset
@@ -186,6 +188,12 @@ func init() {
 	flag.IntVar(&controllerConfig.DefaultBackendMaxConnections, "nginx-default-backend-max-connections",
 		defaultNginxBackendMaxConnections,
 		"Maximum number of connections to a single backend. Can be overridden per ingress with the sky.uk/backend-max-connections annotation.")
+	flag.IntVar(&controllerConfig.DefaultProxyBufferSize, "nginx-default-proxy-buffer-size",
+		defaultNginxProxyBufferSize,
+		"Proxy buffer size for response. Can be overridden per ingress with the sky.uk/proxy-buffer-size annotation.")
+	flag.IntVar(&controllerConfig.DefaultProxyBufferBlocks, "nginx-default-proxy-buffer-blocks",
+		defaultNginxProxyBufferBlocks,
+		"Proxy buffer blocks for response. Can be overridden per ingress with the sky.uk/proxy-buffer-blocks annotation.")
 	flag.StringVar(&nginxConfig.LogLevel, "nginx-loglevel", defaultNginxLogLevel,
 		"Log level for nginx. See http://nginx.org/en/docs/ngx_core_module.html#error_log for levels.")
 	flag.IntVar(&nginxConfig.ServerNamesHashBucketSize, "nginx-server-names-hash-bucket-size", defaultNginxServerNamesHashBucketSize,

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -2,15 +2,11 @@ package main
 
 import (
 	"flag"
-
-	_ "net/http/pprof"
-
-	"time"
-
 	"fmt"
-
+	_ "net/http/pprof"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/alb"

--- a/cmd/feed-ingress/main.go
+++ b/cmd/feed-ingress/main.go
@@ -186,7 +186,7 @@ func init() {
 		"Maximum number of connections to a single backend. Can be overridden per ingress with the sky.uk/backend-max-connections annotation.")
 	flag.IntVar(&controllerConfig.DefaultProxyBufferSize, "nginx-default-proxy-buffer-size",
 		defaultNginxProxyBufferSize,
-		"Proxy buffer size for response. Can be overridden per ingress with the sky.uk/proxy-buffer-size annotation.")
+		"Proxy buffer size for response. Can be overridden per ingress with the sky.uk/proxy-buffer-size-in-kb annotation.")
 	flag.IntVar(&controllerConfig.DefaultProxyBufferBlocks, "nginx-default-proxy-buffer-blocks",
 		defaultNginxProxyBufferBlocks,
 		"Proxy buffer blocks for response. Can be overridden per ingress with the sky.uk/proxy-buffer-blocks annotation.")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -21,19 +21,26 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
-const ingressAllowAnnotation = "sky.uk/allow"
-const frontendSchemeAnnotation = "sky.uk/frontend-scheme"
+const (
+	ingressAllowAnnotation   = "sky.uk/allow"
+	frontendSchemeAnnotation = "sky.uk/frontend-scheme"
 
-// Deprecated: retained to maintain backwards compatibility.
-const frontendElbSchemeAnnotation = "sky.uk/frontend-elb-scheme"
-const stripPathAnnotation = "sky.uk/strip-path"
+	// Deprecated: retained to maintain backwards compatibility.
+	frontendElbSchemeAnnotation = "sky.uk/frontend-elb-scheme"
+	stripPathAnnotation         = "sky.uk/strip-path"
 
-// Old annotation - still supported to maintain backwards compatibility.
-const legacyBackendKeepAliveSeconds = "sky.uk/backend-keepalive-seconds"
-const backendTimeoutSeconds = "sky.uk/backend-timeout-seconds"
+	// Old annotation - still supported to maintain backwards compatibility.
+	legacyBackendKeepAliveSeconds = "sky.uk/backend-keepalive-seconds"
+	backendTimeoutSeconds         = "sky.uk/backend-timeout-seconds"
+	proxyBufferSizeAnnotation     = "sky.uk/proxy-buffer-size"
+	proxyBufferBlocksAnnotation   = "sky.uk/proxy-buffer-blocks"
 
-// sets Nginx (http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns)
-const backendMaxConnections = "sky.uk/backend-max-connections"
+	maxAllowedProxyBufferSize   = 32
+	maxAllowedProxyBufferBlocks = 8
+
+	// sets Nginx (http://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_conns)
+	backendMaxConnections = "sky.uk/backend-max-connections"
+)
 
 // Controller operates on ingress resources, listening for updates and notifying its Updaters.
 type Controller interface {
@@ -52,6 +59,8 @@ type controller struct {
 	defaultStripPath             bool
 	defaultBackendTimeout        int
 	defaultBackendMaxConnections int
+	defaultProxyBufferSize       int
+	defaultProxyBufferBlocks     int
 	watcher                      k8s.Watcher
 	doneCh                       chan struct{}
 	watcherDone                  sync.WaitGroup
@@ -68,6 +77,8 @@ type Config struct {
 	DefaultStripPath             bool
 	DefaultBackendTimeoutSeconds int
 	DefaultBackendMaxConnections int
+	DefaultProxyBufferSize       int
+	DefaultProxyBufferBlocks     int
 }
 
 // New creates an ingress controller.
@@ -79,7 +90,9 @@ func New(conf Config) Controller {
 		defaultStripPath:             conf.DefaultStripPath,
 		defaultBackendTimeout:        conf.DefaultBackendTimeoutSeconds,
 		defaultBackendMaxConnections: conf.DefaultBackendMaxConnections,
-		doneCh: make(chan struct{}),
+		defaultProxyBufferSize:       conf.DefaultProxyBufferSize,
+		defaultProxyBufferBlocks:     conf.DefaultProxyBufferBlocks,
+		doneCh:                       make(chan struct{}),
 	}
 }
 
@@ -175,6 +188,8 @@ func (c *controller) updateIngresses() error {
 						StripPaths:            c.defaultStripPath,
 						BackendTimeoutSeconds: c.defaultBackendTimeout,
 						BackendMaxConnections: c.defaultBackendMaxConnections,
+						ProxyBufferSize:       c.defaultProxyBufferSize,
+						ProxyBufferBlocks:     c.defaultProxyBufferBlocks,
 						CreationTimestamp:     ingress.CreationTimestamp.Time,
 						Ingress:               ingress,
 					}
@@ -218,6 +233,24 @@ func (c *controller) updateIngresses() error {
 					if maxConnections, ok := ingress.Annotations[backendMaxConnections]; ok {
 						tmp, _ := strconv.Atoi(maxConnections)
 						entry.BackendMaxConnections = tmp
+					}
+
+					if proxyBufferSizeString, ok := ingress.Annotations[proxyBufferSizeAnnotation]; ok {
+						tmp, _ := strconv.Atoi(proxyBufferSizeString)
+						entry.ProxyBufferSize = tmp
+						if tmp > maxAllowedProxyBufferSize {
+							log.Warnf("ProxyBufferSize %d has a value which exceeds the max permissible value. Resetting to: %s.", tmp, maxAllowedProxyBufferSize)
+							entry.ProxyBufferSize = maxAllowedProxyBufferSize
+						}
+					}
+
+					if proxyBufferBlocksString, ok := ingress.Annotations[proxyBufferBlocksAnnotation]; ok {
+						tmp, _ := strconv.Atoi(proxyBufferBlocksString)
+						entry.ProxyBufferBlocks = tmp
+						if tmp > maxAllowedProxyBufferBlocks {
+							log.Warnf("ProxyBufferBlocks %d has a value which exceeds the max permissible value. Resetting to: %s.", tmp, maxAllowedProxyBufferBlocks)
+							entry.ProxyBufferBlocks = maxAllowedProxyBufferBlocks
+						}
 					}
 
 					if err := entry.validate(); err == nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -235,7 +235,7 @@ func (c *controller) updateIngresses() error {
 						tmp, _ := strconv.Atoi(proxyBufferSizeString)
 						entry.ProxyBufferSize = tmp
 						if tmp > maxAllowedProxyBufferSize {
-							log.Warnf("ProxyBufferSize %d has a value which exceeds the max permissible value. Resetting to: %s.", tmp, maxAllowedProxyBufferSize)
+							log.Warnf("ProxyBufferSize %d has a value which exceeds the max permissible value. Resetting to: %d.", tmp, maxAllowedProxyBufferSize)
 							entry.ProxyBufferSize = maxAllowedProxyBufferSize
 						}
 					}
@@ -244,7 +244,7 @@ func (c *controller) updateIngresses() error {
 						tmp, _ := strconv.Atoi(proxyBufferBlocksString)
 						entry.ProxyBufferBlocks = tmp
 						if tmp > maxAllowedProxyBufferBlocks {
-							log.Warnf("ProxyBufferBlocks %d has a value which exceeds the max permissible value. Resetting to: %s.", tmp, maxAllowedProxyBufferBlocks)
+							log.Warnf("ProxyBufferBlocks %d has a value which exceeds the max permissible value. Resetting to: %d.", tmp, maxAllowedProxyBufferBlocks)
 							entry.ProxyBufferBlocks = maxAllowedProxyBufferBlocks
 						}
 					}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -235,7 +235,7 @@ func (c *controller) updateIngresses() error {
 						tmp, _ := strconv.Atoi(proxyBufferSizeString)
 						entry.ProxyBufferSize = tmp
 						if tmp > maxAllowedProxyBufferSize {
-							log.Warnf("ProxyBufferSize value %dk exceeds the max permissible value %dk. Hence, %dk will be used instead", tmp, maxAllowedProxyBufferSize, maxAllowedProxyBufferSize)
+							log.Warnf("ProxyBufferSize value %dk exceeds the max permissible value %dk. Using %dk.", tmp, maxAllowedProxyBufferSize, maxAllowedProxyBufferSize)
 							entry.ProxyBufferSize = maxAllowedProxyBufferSize
 						}
 					}
@@ -244,7 +244,7 @@ func (c *controller) updateIngresses() error {
 						tmp, _ := strconv.Atoi(proxyBufferBlocksString)
 						entry.ProxyBufferBlocks = tmp
 						if tmp > maxAllowedProxyBufferBlocks {
-							log.Warnf("ProxyBufferBlocks value %d exceeds the max permissible value %d. Hence, %d will be used instead", tmp, maxAllowedProxyBufferBlocks, maxAllowedProxyBufferBlocks)
+							log.Warnf("ProxyBufferBlocks value %d exceeds the max permissible value %d. Using %d", tmp, maxAllowedProxyBufferBlocks, maxAllowedProxyBufferBlocks)
 							entry.ProxyBufferBlocks = maxAllowedProxyBufferBlocks
 						}
 					}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -28,7 +28,7 @@ const (
 	// Old annotation - still supported to maintain backwards compatibility.
 	legacyBackendKeepAliveSeconds = "sky.uk/backend-keepalive-seconds"
 	backendTimeoutSeconds         = "sky.uk/backend-timeout-seconds"
-	proxyBufferSizeAnnotation     = "sky.uk/proxy-buffer-size"
+	proxyBufferSizeAnnotation     = "sky.uk/proxy-buffer-size-in-kb"
 	proxyBufferBlocksAnnotation   = "sky.uk/proxy-buffer-blocks"
 
 	maxAllowedProxyBufferSize   = 32
@@ -235,7 +235,7 @@ func (c *controller) updateIngresses() error {
 						tmp, _ := strconv.Atoi(proxyBufferSizeString)
 						entry.ProxyBufferSize = tmp
 						if tmp > maxAllowedProxyBufferSize {
-							log.Warnf("ProxyBufferSize %d has a value which exceeds the max permissible value. Resetting to: %d.", tmp, maxAllowedProxyBufferSize)
+							log.Warnf("ProxyBufferSize value %dk exceeds the max permissible value %dk. Hence, %dk will be used instead", tmp, maxAllowedProxyBufferSize, maxAllowedProxyBufferSize)
 							entry.ProxyBufferSize = maxAllowedProxyBufferSize
 						}
 					}
@@ -244,7 +244,7 @@ func (c *controller) updateIngresses() error {
 						tmp, _ := strconv.Atoi(proxyBufferBlocksString)
 						entry.ProxyBufferBlocks = tmp
 						if tmp > maxAllowedProxyBufferBlocks {
-							log.Warnf("ProxyBufferBlocks %d has a value which exceeds the max permissible value. Resetting to: %d.", tmp, maxAllowedProxyBufferBlocks)
+							log.Warnf("ProxyBufferBlocks value %d exceeds the max permissible value %d. Hence, %d will be used instead", tmp, maxAllowedProxyBufferBlocks, maxAllowedProxyBufferBlocks)
 							entry.ProxyBufferBlocks = maxAllowedProxyBufferBlocks
 						}
 					}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -5,15 +5,11 @@ It delegates update logic to an Updater interface.
 package controller
 
 import (
-	"sync"
-
-	"fmt"
-
-	"strings"
-
-	"strconv"
-
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/k8s"

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -336,21 +336,36 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with missing host name",
-			createIngressesFixture("", ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: ingressAllow, backendTimeoutSeconds: "10", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture("", ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      ingressAllow,
+					backendTimeoutSeconds:       "10",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			nil,
 			defaultConfig(),
 		},
 		{
 			"ingress with missing service name",
-			createIngressesFixture(ingressHost, "", ingressSvcPort, map[string]string{ingressAllowAnnotation: ingressAllow, backendTimeoutSeconds: "10", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, "", ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      ingressAllow,
+					backendTimeoutSeconds:       "10",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			nil,
 			defaultConfig(),
 		},
 		{
 			"ingress with missing service port",
-			createIngressesFixture(ingressHost, ingressSvcName, 0, map[string]string{ingressAllowAnnotation: ingressAllow, backendTimeoutSeconds: "10", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, ingressSvcName, 0,
+				map[string]string{
+					ingressAllowAnnotation:      ingressAllow,
+					backendTimeoutSeconds:       "10",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			nil,
 			defaultConfig(),
@@ -371,7 +386,10 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with default allow",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{backendTimeoutSeconds: "10"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					backendTimeoutSeconds: "10",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -387,7 +405,12 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with empty allow",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", backendTimeoutSeconds: "10", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					backendTimeoutSeconds:       "10",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -404,7 +427,13 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with strip paths set to true",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", stripPathAnnotation: "true", backendTimeoutSeconds: "10", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					stripPathAnnotation:         "true",
+					backendTimeoutSeconds:       "10",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -422,7 +451,13 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with strip paths set to false",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", stripPathAnnotation: "false", backendTimeoutSeconds: "10", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					stripPathAnnotation:         "false",
+					backendTimeoutSeconds:       "10",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -440,7 +475,13 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with overridden backend timeout",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", stripPathAnnotation: "false", backendTimeoutSeconds: "20", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					stripPathAnnotation:         "false",
+					backendTimeoutSeconds:       "20",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -458,7 +499,12 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with default backend timeout",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", stripPathAnnotation: "false", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					stripPathAnnotation:         "false",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -476,7 +522,14 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with overridden backend max connections",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", stripPathAnnotation: "false", backendTimeoutSeconds: "20", frontendElbSchemeAnnotation: "internal", backendMaxConnections: "512"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					stripPathAnnotation:         "false",
+					backendTimeoutSeconds:       "20",
+					frontendElbSchemeAnnotation: "internal",
+					backendMaxConnections:       "512",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -495,7 +548,13 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with default backend max connections",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", stripPathAnnotation: "false", backendTimeoutSeconds: "20", frontendElbSchemeAnnotation: "internal"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					stripPathAnnotation:         "false",
+					backendTimeoutSeconds:       "20",
+					frontendElbSchemeAnnotation: "internal",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -514,7 +573,10 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress with default proxy buffer values when not overridden by the ingress definition",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: ""}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation: "",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -539,7 +601,12 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress definition overrides default proxy buffer values",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", proxyBufferSizeAnnotation: "6", proxyBufferBlocksAnnotation: "4"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					proxyBufferSizeAnnotation:   "6",
+					proxyBufferBlocksAnnotation: "4",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -564,7 +631,12 @@ func TestUpdaterIsUpdatedOnK8sUpdates(t *testing.T) {
 		},
 		{
 			"ingress definition resets to max when proxy buffer values exceed max allowed values",
-			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: "", proxyBufferSizeAnnotation: "64", proxyBufferBlocksAnnotation: "12"}),
+			createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+				map[string]string{
+					ingressAllowAnnotation:      "",
+					proxyBufferSizeAnnotation:   "64",
+					proxyBufferBlocksAnnotation: "12",
+				}),
 			createDefaultServices(),
 			[]IngressEntry{{
 				Namespace:             ingressNamespace,
@@ -673,11 +745,21 @@ const (
 )
 
 func createDefaultIngresses() []*v1beta1.Ingress {
-	return createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: ingressAllow, backendTimeoutSeconds: "10", frontendElbSchemeAnnotation: "internal"})
+	return createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+		map[string]string{
+			ingressAllowAnnotation:      ingressAllow,
+			backendTimeoutSeconds:       "10",
+			frontendElbSchemeAnnotation: "internal",
+		})
 }
 
 func createIngressesFromNonELBAnnotation() []*v1beta1.Ingress {
-	return createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort, map[string]string{ingressAllowAnnotation: ingressAllow, backendTimeoutSeconds: "10", frontendSchemeAnnotation: "internal"})
+	return createIngressesFixture(ingressHost, ingressSvcName, ingressSvcPort,
+		map[string]string{
+			ingressAllowAnnotation:   ingressAllow,
+			backendTimeoutSeconds:    "10",
+			frontendSchemeAnnotation: "internal",
+		})
 }
 
 func createIngressesFixture(host string, serviceName string, servicePort int, ingressAnnotations map[string]string) []*v1beta1.Ingress {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,14 +1,11 @@
 package controller
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
-
 	"time"
-
-	"fmt"
-
-	"errors"
 
 	"github.com/sky-uk/feed/k8s"
 	fake "github.com/sky-uk/feed/util/test"

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -40,9 +40,9 @@ type IngressEntry struct {
 	CreationTimestamp time.Time
 	// Ingress resource
 	Ingress *v1beta1.Ingress
-	//
+	// Size of the buffer used for reading the first part of the response received from the proxied server.
 	ProxyBufferSize int
-	//
+	// Number of buffers used for reading a response from the proxied server, for a single connection.
 	ProxyBufferBlocks int
 }
 

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -40,6 +40,11 @@ type IngressEntry struct {
 	CreationTimestamp time.Time
 	// Ingress resource
 	Ingress *v1beta1.Ingress
+	//
+	ProxyBufferSize int
+	//
+	ProxyBufferBlocks int
+
 }
 
 // validate returns error if entry has invalid fields.

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -44,7 +44,6 @@ type IngressEntry struct {
 	ProxyBufferSize int
 	//
 	ProxyBufferBlocks int
-
 }
 
 // validate returns error if entry has invalid fields.

--- a/dns/adapter/aws_adapter.go
+++ b/dns/adapter/aws_adapter.go
@@ -2,15 +2,13 @@ package adapter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	aws_elb "github.com/aws/aws-sdk-go/service/elb"
 	aws_alb "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/route53"
-
-	"strings"
-
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/sky-uk/feed/elb"
 )
 

--- a/dns/dns_updater.go
+++ b/dns/dns_updater.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"fmt"
-
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/route53"

--- a/dns/dns_updater_test.go
+++ b/dns/dns_updater_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/dns/r53/client_test.go
+++ b/dns/r53/client_test.go
@@ -1,9 +1,8 @@
 package r53
 
 import (
-	"testing"
-
 	"errors"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -4,12 +4,9 @@ Package elb provides an updater for an ELB frontend to attach nginx to.
 package elb
 
 import (
-	"fmt"
-
 	"errors"
-
+	"fmt"
 	"sync"
-
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -86,8 +85,8 @@ func mockLoadBalancers(m *fakeElb, lbs ...lb) {
 		descriptions = append(descriptions, &aws_elb.LoadBalancerDescription{
 			LoadBalancerName:          aws.String(lb.name),
 			CanonicalHostedZoneNameID: aws.String(canonicalHostedZoneNameID),
-			Scheme:  aws.String(lb.scheme),
-			DNSName: aws.String(elbDNSName),
+			Scheme:                    aws.String(lb.scheme),
+			DNSName:                   aws.String(elbDNSName),
 		})
 
 	}

--- a/elb/status/status.go
+++ b/elb/status/status.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	aws_elb "github.com/aws/aws-sdk-go/service/elb"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/elb"
 	"github.com/sky-uk/feed/k8s"
-	"k8s.io/client-go/pkg/api/v1"
-
-	aws_elb "github.com/aws/aws-sdk-go/service/elb"
 	k8s_status "github.com/sky-uk/feed/k8s/status"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // Config for creating a new ELB status updater.

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -4,23 +4,18 @@ Package gorb provide the ability to register and deregister the backend
 package gorb
 
 import (
-	"errors"
-
-	"time"
-
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os/exec"
-	"strings"
-
-	"io"
-
 	"path"
-
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/sethgrid/pester"

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -7,10 +7,9 @@ The types are copied from the stable api of the Kubernetes 1.3 release.
 package k8s
 
 import (
+	"errors"
 	"sync"
 	"time"
-
-	"errors"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -180,6 +180,6 @@ func (w *handlerWatcher) OnUpdate(old interface{}, new interface{}) {
 }
 
 func (w *handlerWatcher) OnDelete(obj interface{}) {
-	log.Debug("OnDelete called for %v - updating watcher", obj)
+	log.Debugf("OnDelete called for %v - updating watcher", obj)
 	go w.notify()
 }

--- a/k8s/status/status.go
+++ b/k8s/status/status.go
@@ -1,10 +1,9 @@
 package status
 
 import (
+	"fmt"
 	"net"
 	"sort"
-
-	"fmt"
 
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/k8s"

--- a/k8s/status/status_test.go
+++ b/k8s/status/status_test.go
@@ -1,16 +1,14 @@
 package status
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/sky-uk/feed/controller"
+	fake "github.com/sky-uk/feed/util/test"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/pkg/api/v1"
-
-	"errors"
-
-	fake "github.com/sky-uk/feed/util/test"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 

--- a/k8s/watcher.go
+++ b/k8s/watcher.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"sync"
-
 	"time"
 
 	log "github.com/sirupsen/logrus"

--- a/k8s/watcher_test.go
+++ b/k8s/watcher_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"testing"
-
 	"time"
 
 	"github.com/sky-uk/feed/util"

--- a/merlin/merlin.go
+++ b/merlin/merlin.go
@@ -1,9 +1,8 @@
 package merlin
 
 import (
-	"fmt"
-
 	"context"
+	"fmt"
 	"strings"
 	"time"
 

--- a/merlin/merlin_test.go
+++ b/merlin/merlin_test.go
@@ -1,13 +1,10 @@
 package merlin
 
 import (
-	"testing"
-
-	"time"
-
 	"errors"
-
 	"fmt"
+	"testing"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"

--- a/merlin/netlink.go
+++ b/merlin/netlink.go
@@ -2,7 +2,6 @@ package merlin
 
 import (
 	"fmt"
-
 	"strings"
 
 	"github.com/vishvananda/netlink"

--- a/merlin/status/status.go
+++ b/merlin/status/status.go
@@ -6,9 +6,8 @@ package status
 import (
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/k8s"
-	"k8s.io/client-go/pkg/api/v1"
-
 	k8s_status "github.com/sky-uk/feed/k8s/status"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 const (

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -137,6 +137,8 @@ type location struct {
 	Allow                 []string
 	StripPath             bool
 	BackendTimeoutSeconds int
+	ProxyBufferSize       int
+	ProxyBufferBlocks     int
 }
 
 func (c *Conf) nginxConfFile() string {
@@ -455,6 +457,8 @@ func createServerEntries(entries controller.IngressEntries) []*server {
 			Allow:                 ingressEntry.Allow,
 			StripPath:             ingressEntry.StripPaths,
 			BackendTimeoutSeconds: ingressEntry.BackendTimeoutSeconds,
+			ProxyBufferSize:       ingressEntry.ProxyBufferSize,
+			ProxyBufferBlocks:     ingressEntry.ProxyBufferBlocks,
 		}
 
 		serverEntry.Names = append(serverEntry.Names, ingressEntry.NamespaceName())

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -1,24 +1,18 @@
 package nginx
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
-
-	"bytes"
-	"fmt"
-	"text/template"
-
+	"sort"
 	"strings"
-
-	"time"
-
 	"sync"
 	"syscall"
-
-	"errors"
-
-	"sort"
+	"text/template"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -156,6 +156,8 @@ http {
             # Close proxy connections after backend keepalive time.
             proxy_read_timeout {{ $location.BackendTimeoutSeconds }}s;
             proxy_send_timeout {{ $location.BackendTimeoutSeconds }}s;
+            proxy_buffer_size {{ $location.ProxyBufferSize }}k;
+            proxy_buffers {{ $location.ProxyBufferBlocks }} {{ $location.ProxyBufferSize }}k;
 
             # Allow localhost for debugging
             allow 127.0.0.1;

--- a/nginx/nginx_metrics.go
+++ b/nginx/nginx_metrics.go
@@ -1,15 +1,12 @@
 package nginx
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-
-	"sync"
-
-	"encoding/json"
-
 	"strings"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -1,20 +1,17 @@
 package nginx
 
 import (
-	"testing"
-
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"regexp"
-	"strings"
-
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"regexp"
 	"strconv"
-
+	"strings"
+	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -453,6 +453,8 @@ func TestNginxIngressEntries(t *testing.T) {
 					"            # Close proxy connections after backend keepalive time.\n" +
 					"            proxy_read_timeout 10s;\n" +
 					"            proxy_send_timeout 10s;\n" +
+					"            proxy_buffer_size 0k;\n" +
+					"            proxy_buffers 0 0k;\n" +
 					"\n" +
 					"            # Allow localhost for debugging\n" +
 					"            allow 127.0.0.1;\n" +
@@ -474,6 +476,8 @@ func TestNginxIngressEntries(t *testing.T) {
 					"            # Close proxy connections after backend keepalive time.\n" +
 					"            proxy_read_timeout 1s;\n" +
 					"            proxy_send_timeout 1s;\n" +
+					"            proxy_buffer_size 0k;\n" +
+					"            proxy_buffers 0 0k;\n" +
 					"\n" +
 					"            # Allow localhost for debugging\n" +
 					"            allow 127.0.0.1;\n" +
@@ -820,6 +824,8 @@ func TestNginxIngressEntries(t *testing.T) {
 					"            # Close proxy connections after backend keepalive time.\n" +
 					"            proxy_read_timeout 28s;\n" +
 					"            proxy_send_timeout 28s;\n" +
+					"            proxy_buffer_size 0k;\n" +
+					"            proxy_buffers 0 0k;\n" +
 					"\n" +
 					"            # Allow localhost for debugging\n" +
 					"            allow 127.0.0.1;\n" +
@@ -839,6 +845,8 @@ func TestNginxIngressEntries(t *testing.T) {
 					"            # Close proxy connections after backend keepalive time.\n" +
 					"            proxy_read_timeout 28s;\n" +
 					"            proxy_send_timeout 28s;\n" +
+					"            proxy_buffer_size 0k;\n" +
+					"            proxy_buffers 0 0k;\n" +
 					"\n" +
 					"            # Allow localhost for debugging\n" +
 					"            allow 127.0.0.1;\n" +
@@ -858,6 +866,8 @@ func TestNginxIngressEntries(t *testing.T) {
 					"            # Close proxy connections after backend keepalive time.\n" +
 					"            proxy_read_timeout 28s;\n" +
 					"            proxy_send_timeout 28s;\n" +
+					"            proxy_buffer_size 0k;\n" +
+					"            proxy_buffers 0 0k;\n" +
 					"\n" +
 					"            # Allow localhost for debugging\n" +
 					"            allow 127.0.0.1;\n" +
@@ -884,6 +894,45 @@ func TestNginxIngressEntries(t *testing.T) {
 			nil,
 			[]string{
 				"ssl_protocols TLSv1.2;",
+			},
+		},
+		{
+			"Proxy and buffer size is configurable",
+			sslEndpointConf,
+			[]controller.IngressEntry{
+				{
+					Host:              "default-proxy-buffer.com",
+					Namespace:         "core",
+					Name:              "some-ingress",
+					Path:              "/some-path",
+					ServiceAddress:    "service",
+					ServicePort:       9090,
+					ProxyBufferSize:   8,
+					ProxyBufferBlocks: 8,
+				},
+			},
+			nil,
+			[]string{
+				"        location /some-path/ {\n" +
+					"            # Keep original path when proxying.\n" +
+					"            proxy_pass http://core.service.9090;\n" +
+					"\n" +
+					"            # Set display name for vhost stats.\n" +
+					"            vhost_traffic_status_filter_by_set_key /some-path/::$proxy_host $server_name;\n" +
+					"\n" +
+					"            # Close proxy connections after backend keepalive time.\n" +
+					"            proxy_read_timeout 0s;\n" +
+					"            proxy_send_timeout 0s;\n" +
+					"            proxy_buffer_size 8k;\n" +
+					"            proxy_buffers 8 8k;\n" +
+					"\n" +
+					"            # Allow localhost for debugging\n" +
+					"            allow 127.0.0.1;\n" +
+					"\n" +
+					"            # Restrict clients\n" +
+					"            \n" +
+					"            deny all;\n" +
+					"        }\n",
 			},
 		},
 	}

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -1,15 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
-
-	"fmt"
-
 	"time"
 
 	"github.com/onrik/logrus/filename"


### PR DESCRIPTION
- The default proxy buffer size has been changed to 16k
- The default proxy buffer blocks has been changed to 4 16k
- Both of the above values can be overridden with the relevant
annotations
- There is a max permissible value and if the annotated value exceeds
that, it will be reset to the max permissible value for both of the
above fields.