### PR TITLE
Remove AND operator in nginx template

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -49,11 +49,13 @@ http {
     client_body_buffer_size {{ .ClientBodyBufferSize }}k;
     {{ end }}
 
-    {{ if .LargeClientHeaderBufferBlocks }} AND {{ if .ClientHeaderBufferSize }}
-        # Sets the maximum number of buffers used for reading large client request header.
-        # The size would be same as client_header_buffer_size. A request line cannot exceed the size of one buffer
-        large_client_header_buffers {{ .LargeClientHeaderBufferBlocks }} {{ .ClientHeaderBufferSize }}k;
-    {{ end }} {{ end }}
+    {{ if .LargeClientHeaderBufferBlocks }}
+        {{ if .ClientHeaderBufferSize }}
+            # Sets the maximum number of buffers used for reading large client request header.
+            # The size would be same as client_header_buffer_size. A request line cannot exceed the size of one buffer
+            large_client_header_buffers {{ .LargeClientHeaderBufferBlocks }} {{ .ClientHeaderBufferSize }}k;
+        {{ end }}
+    {{ end }}
 
     # Obtain client IP from frontend
 {{ range .TrustedFrontends }}    set_real_ip_from {{ . }};


### PR DESCRIPTION
AND was being left behind as a literal and nginx fails to start. This commit will fix that