### PR TITLE
Fix duplicate path when path is not specified

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/k8s"
 	"github.com/sky-uk/feed/util"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 const (

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -11,7 +11,7 @@ import (
 	fake "github.com/sky-uk/feed/util/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/util/intstr"
 )

--- a/elb/status/status.go
+++ b/elb/status/status.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sky-uk/feed/elb"
 	"github.com/sky-uk/feed/k8s"
 	k8s_status "github.com/sky-uk/feed/k8s/status"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 // Config for creating a new ELB status updater.

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/sethgrid/pester"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -13,7 +13,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/fields"
 	"k8s.io/client-go/tools/cache"

--- a/k8s/status/status.go
+++ b/k8s/status/status.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/k8s"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 // GenerateLoadBalancerStatus to convert a slice of strings to ingress loadbalancer objects.

--- a/k8s/status/status_test.go
+++ b/k8s/status/status_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sky-uk/feed/controller"
 	fake "github.com/sky-uk/feed/util/test"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 

--- a/merlin/status/status.go
+++ b/merlin/status/status.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/k8s"
 	k8s_status "github.com/sky-uk/feed/k8s/status"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 const (

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -454,7 +454,7 @@ func createServerEntries(entries controller.IngressEntries) []*server {
 		}
 
 		location := location{
-			Path:                  createNginxPath(ingressEntry.Path),
+			Path:                  ingressEntry.Path,
 			UpstreamID:            upstreamID(ingressEntry),
 			Allow:                 ingressEntry.Allow,
 			StripPath:             ingressEntry.StripPaths,
@@ -494,6 +494,7 @@ func uniqueIngressEntries(entries controller.IngressEntries) []controller.Ingres
 
 	uniqueIngress := make(map[ingressKey]controller.IngressEntry)
 	for _, ingressEntry := range entries {
+		ingressEntry.Path = createNginxPath(ingressEntry.Path)
 		key := ingressKey{ingressEntry.Host, ingressEntry.Path}
 		existingIngressEntry, exists := uniqueIngress[key]
 		if !exists {

--- a/util/test/mocks.go
+++ b/util/test/mocks.go
@@ -3,7 +3,7 @@ package test
 import (
 	"github.com/sky-uk/feed/k8s"
 	"github.com/stretchr/testify/mock"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 


### PR DESCRIPTION
This fixes the issue where a duplicate ingress arises between a
path that has not been specified and a path of "/"

Connects https://github.com/sky-uk/core-infrastructure/issues/3686