### PR TITLE
Remove unnecessary config reload after start up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v1.12.2
+* Formatting changes
+  https://github.com/sky-uk/feed/pull/190
+* Fix duplicate path when path is not specified
+  https://github.com/sky-uk/feed/pull/193
+* Remove unnecessary config reload after start up
+  https://github.com/sky-uk/feed/pull/194
+
+# v1.12.1
+* Fix bug in v1.12.0 with the nginx.conf template
+  https://github.com/sky-uk/feed/pull/188
+
 # v1.12.0
 * Enable overriding proxy buffer values. Defaults to `proxy_buffer_size 16k` and `proxy_buffers 4 16k`
 Can be overridden with relevant annotations

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -151,11 +151,11 @@ func TestUnhealthyUntilInitialUpdate(t *testing.T) {
 	conf.HealthPort = getPort(ts)
 	lb := newNginxWithConf(conf)
 
-	assert.EqualError(lb.Health(), "waiting for initial update")
+	assert.EqualError(lb.Health(), "nginx is not running")
 	assert.NoError(lb.Start())
 
 	time.Sleep(smallWaitTime)
-	assert.EqualError(lb.Health(), "waiting for initial update")
+	assert.EqualError(lb.Health(), "nginx is not running")
 	assert.NoError(lb.Update([]controller.IngressEntry{{
 		Host: "james.com",
 	}}))


### PR DESCRIPTION
We start nginx after generating the config so we don't need to signal a
reload.  This was causing nginx to reload the config 5 minutes after
every startup which we know can be disruptive and is unnecessary.

Set the 'initial update' flag after starting nginx as this will ensure we
don't return true on the health endpoing before nginx is running.
Previously we set this flag just before starting nginx so it's
possible we were reporting healthy before the process was running.