### PR TITLE
Fix most recent CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.12.4
+# v1.13.0
 * Add support for exact paths when specified as locations
   https://github.com/sky-uk/feed/pull/197
 


### PR DESCRIPTION
Ought to have been released as v1.13.0, as this change introduces new backwards-compatible functionality.