### PR TITLE
[WIP] Upgrade AWS ELB library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint :
 		golint -set_exit_status $$pkg || exit 1; \
 	done;
 
-test :
+test : build
 	@echo "== run tests"
 	@go test -race $(pkgs)
 
@@ -62,7 +62,7 @@ git_rev := $(shell git rev-parse --short HEAD)
 git_tag := $(shell git tag --points-at=$(git_rev))
 image_prefix := skycirrus/feed
 
-docker : build
+docker : test
 	@echo "== build docker images"
 	cp $(GOPATH)/bin/feed-dns docker/dns
 	cp $(GOPATH)/bin/feed-ingress docker/ingress

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	aws_alb "github.com/aws/aws-sdk-go/service/elbv2"
+	awselb "github.com/aws/aws-sdk-go/service/elbv2"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util"
@@ -33,7 +33,7 @@ func New(region string, targetGroupNames []string, targetGroupDeregistrationDela
 
 	return &alb{
 		metadata:                       ec2metadata.New(session),
-		awsALB:                         aws_alb.New(session),
+		awsALB:                         awselb.New(session),
 		targetGroupNames:               targetGroupNames,
 		targetGroupDeregistrationDelay: targetGroupDeregistrationDelay,
 		region:                         region,
@@ -62,9 +62,9 @@ type initialised struct {
 // ALB interface to allow mocking of real calls to AWS as well as cutting down the methods from the real
 // interface to only the ones we use
 type ALB interface {
-	DescribeTargetGroups(input *aws_alb.DescribeTargetGroupsInput) (*aws_alb.DescribeTargetGroupsOutput, error)
-	RegisterTargets(input *aws_alb.RegisterTargetsInput) (*aws_alb.RegisterTargetsOutput, error)
-	DeregisterTargets(input *aws_alb.DeregisterTargetsInput) (*aws_alb.DeregisterTargetsOutput, error)
+	DescribeTargetGroups(input *awselb.DescribeTargetGroupsInput) (*awselb.DescribeTargetGroupsOutput, error)
+	RegisterTargets(input *awselb.RegisterTargetsInput) (*awselb.RegisterTargetsOutput, error)
+	DeregisterTargets(input *awselb.DeregisterTargetsInput) (*awselb.DeregisterTargetsOutput, error)
 }
 
 // EC2Metadata interface to allow mocking of the real calls to AWS
@@ -98,9 +98,9 @@ func (a *alb) Stop() error {
 	for _, arn := range a.albARNs {
 		log.Infof("Deregistering instance %s with ALB target group %s", a.instanceID, *arn)
 
-		_, err := a.awsALB.DeregisterTargets(&aws_alb.DeregisterTargetsInput{
+		_, err := a.awsALB.DeregisterTargets(&awselb.DeregisterTargetsInput{
 			TargetGroupArn: arn,
-			Targets: []*aws_alb.TargetDescription{
+			Targets: []*awselb.TargetDescription{
 				{Id: aws.String(a.instanceID)},
 			},
 		})
@@ -151,9 +151,9 @@ func (a *alb) attachToFrontEnds() error {
 	for _, arn := range arns {
 		log.Infof("Registering instance %s with alb %s", instanceID, *arn)
 
-		_, err = a.awsALB.RegisterTargets(&aws_alb.RegisterTargetsInput{
+		_, err = a.awsALB.RegisterTargets(&awselb.RegisterTargetsInput{
 			TargetGroupArn: arn,
-			Targets: []*aws_alb.TargetDescription{
+			Targets: []*awselb.TargetDescription{
 				{Id: aws.String(instanceID)},
 			},
 		})
@@ -175,7 +175,7 @@ func (a *alb) attachToFrontEnds() error {
 }
 
 func (a *alb) findTargetGroupARNs(names []string) ([]*string, error) {
-	req := &aws_alb.DescribeTargetGroupsInput{Names: aws.StringSlice(names)}
+	req := &awselb.DescribeTargetGroupsInput{Names: aws.StringSlice(names)}
 	var arns []*string
 
 	for {

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -1,5 +1,5 @@
 /*
-Package alb provides an updater for an ALB frontend to attach nginx to.
+Package alb provides an updater for an ALB frontend to attach NGINX to.
 */
 package alb
 
@@ -25,15 +25,15 @@ func New(region string, targetGroupNames []string, targetGroupDeregistrationDela
 	}
 	initMetrics()
 	log.Infof("ALB frontend region: %s target groups: %v", region, targetGroupNames)
-	session, err := session.NewSession(&aws.Config{Region: &region})
+	awsSession, err := session.NewSession(&aws.Config{Region: &region})
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ALB updater: %v", err)
 	}
 
 	return &alb{
-		metadata:                       ec2metadata.New(session),
-		awsALB:                         awselb.New(session),
+		metadata:                       ec2metadata.New(awsSession),
+		awsALB:                         awselb.New(awsSession),
 		targetGroupNames:               targetGroupNames,
 		targetGroupDeregistrationDelay: targetGroupDeregistrationDelay,
 		region:                         region,

--- a/alb/alb_test.go
+++ b/alb/alb_test.go
@@ -61,10 +61,6 @@ func (m *mockMetadata) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIde
 	return args.Get(0).(ec2metadata.EC2InstanceIdentityDocument), args.Error(1)
 }
 
-type targetGroup struct {
-	name string
-}
-
 func (m *mockALB) mockDescribeTargetGroups(names []string, arns []string, reqMarker *string, nextMarker *string, err error) {
 	var awsNames []*string
 	var targetGroups []*awselb.TargetGroup
@@ -179,7 +175,7 @@ func TestErrorDescribingTargetGroups(t *testing.T) {
 	mockALB.mockDescribeTargetGroups([]string{"group"}, []string{"group-arn"}, nil, nil, errors.New("ba koom"))
 
 	//when
-	a.Start()
+	_ = a.Start()
 	updateErr := a.Update(controller.IngressEntries{})
 
 	//then
@@ -240,8 +236,8 @@ func TestDeregistersOnStop(t *testing.T) {
 	mockALB.mockDeregisterTargets("external-arn", instanceID, nil)
 
 	//when
-	a.Start()
-	a.Update(controller.IngressEntries{})
+	_ = a.Start()
+	_ = a.Update(controller.IngressEntries{})
 	stopErr := a.Stop()
 
 	//then
@@ -263,8 +259,8 @@ func TestDeregisterErrorIsHandledInStop(t *testing.T) {
 	mockALB.mockDeregisterTargets("external-arn", instanceID, nil)
 
 	//when
-	a.Start()
-	a.Update(controller.IngressEntries{})
+	_ = a.Start()
+	_ = a.Update(controller.IngressEntries{})
 	stopErr := a.Stop()
 
 	//then
@@ -287,10 +283,10 @@ func TestStopWaitsForDeregisterDelay(t *testing.T) {
 	a.(*alb).targetGroupDeregistrationDelay = time.Millisecond * 50
 
 	//when
-	a.Start()
-	a.Update(controller.IngressEntries{})
+	_ = a.Start()
+	_ = a.Update(controller.IngressEntries{})
 	beforeStop := time.Now()
-	a.Stop()
+	_ = a.Stop()
 	stopDuration := time.Now().Sub(beforeStop)
 
 	//then

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -28,7 +28,7 @@ type IngressEntry struct {
 	ServiceAddress string
 	// ServicePort is the port to proxy traffic to. Must be non-zero.
 	ServicePort int32
-	// Allow are the ips or cidrs that are allowed to access the service.
+	// Allow are the ips or CIDRs that are allowed to access the service.
 	Allow []string
 	// LbScheme internet-facing or internal will dictate which kind of load balancer to attach to.
 	LbScheme string

--- a/dns/adapter/aws_adapter.go
+++ b/dns/adapter/aws_adapter.go
@@ -6,18 +6,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	aws_elb "github.com/aws/aws-sdk-go/service/elb"
-	aws_alb "github.com/aws/aws-sdk-go/service/elbv2"
+	awselb "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/sky-uk/feed/elb"
 )
 
-// FindELBsFunc defines a function which find ELBs based on a label
-type FindELBsFunc func(elb.ELB, string) (map[string]elb.LoadBalancerDetails, error)
+// FindELBsFunc defines a function which find ELBs based on a tag value
+type FindELBsFunc func(elb elb.ELB, tagValue string) (map[string]elb.LoadBalancerDetails, error)
 
 // ALB represents the subset of AWS operations needed for dns_updater.go
 type ALB interface {
-	DescribeLoadBalancers(input *aws_alb.DescribeLoadBalancersInput) (*aws_alb.DescribeLoadBalancersOutput, error)
+	DescribeLoadBalancers(input *awselb.DescribeLoadBalancersInput) (*awselb.DescribeLoadBalancersOutput, error)
 }
 
 // AWSAdapterConfig describes the configuration of a FrontendAdapter which uses AWS ELBs and/or ALBs
@@ -48,8 +47,8 @@ func NewAWSAdapter(config *AWSAdapterConfig) (FrontendAdapter, error) {
 			return nil, fmt.Errorf("unable to open AWS session: %v", err)
 		}
 
-		config.ALBClient = aws_alb.New(session)
-		config.ELBClient = aws_elb.New(session)
+		config.ALBClient = awselb.New(session)
+		config.ELBClient = awselb.New(session)
 	}
 
 	if config.ELBFinder == nil {
@@ -110,7 +109,7 @@ func (a *awsAdapter) initALBs(schemeToFrontendMap map[string]DNSDetails) error {
 		return nil
 	}
 
-	req := &aws_alb.DescribeLoadBalancersInput{Names: aws.StringSlice(a.albNames)}
+	req := &awselb.DescribeLoadBalancersInput{Names: aws.StringSlice(a.albNames)}
 
 	for {
 		resp, err := a.alb.DescribeLoadBalancers(req)

--- a/dns/adapter/aws_adapter.go
+++ b/dns/adapter/aws_adapter.go
@@ -42,13 +42,13 @@ type awsAdapter struct {
 // NewAWSAdapter creates a FrontendAdapter which interacts with AWS ELBs or ALBs.
 func NewAWSAdapter(config *AWSAdapterConfig) (FrontendAdapter, error) {
 	if config.ALBClient == nil && config.ELBClient == nil {
-		session, err := session.NewSession(&aws.Config{Region: &config.Region})
+		awsSession, err := session.NewSession(&aws.Config{Region: &config.Region})
 		if err != nil {
 			return nil, fmt.Errorf("unable to open AWS session: %v", err)
 		}
 
-		config.ALBClient = awselb.New(session)
-		config.ELBClient = awselb.New(session)
+		config.ALBClient = awselb.New(awsSession)
+		config.ELBClient = awselb.New(awsSession)
 	}
 
 	if config.ELBFinder == nil {

--- a/dns/dns_updater.go
+++ b/dns/dns_updater.go
@@ -179,7 +179,7 @@ func (u *updater) createChanges(hostToIngress hostToIngress,
 	originalRecords []adapter.ConsolidatedRecord) ([]*route53.Change, []string) {
 
 	type recordKey struct{ host, elbDNSName string }
-	changes := []*route53.Change{}
+	var changes []*route53.Change
 	indexedRecords := make(map[recordKey]adapter.ConsolidatedRecord)
 	for _, rec := range originalRecords {
 		indexedRecords[recordKey{rec.Name, rec.PointsTo}] = rec

--- a/dns/dns_updater_test.go
+++ b/dns/dns_updater_test.go
@@ -7,8 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	aws_elb "github.com/aws/aws-sdk-go/service/elb"
-	aws_alb "github.com/aws/aws-sdk-go/service/elbv2"
+	awselb "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sky-uk/feed/controller"
@@ -58,27 +57,27 @@ type mockALB struct {
 	mock.Mock
 }
 
-func (m *mockALB) DescribeLoadBalancers(input *aws_alb.DescribeLoadBalancersInput) (*aws_alb.DescribeLoadBalancersOutput, error) {
+func (m *mockALB) DescribeLoadBalancers(input *awselb.DescribeLoadBalancersInput) (*awselb.DescribeLoadBalancersOutput, error) {
 	args := m.Called(input)
-	return args.Get(0).(*aws_alb.DescribeLoadBalancersOutput), args.Error(1)
+	return args.Get(0).(*awselb.DescribeLoadBalancersOutput), args.Error(1)
 }
 
 func (m *mockALB) mockDescribeLoadBalancers(names []string, lbDetails []lbDetail, err error) {
-	var lbs []*aws_alb.LoadBalancer
+	var lbs []*awselb.LoadBalancer
 
 	for _, lb := range lbDetails {
-		lbs = append(lbs, &aws_alb.LoadBalancer{
+		lbs = append(lbs, &awselb.LoadBalancer{
 			Scheme:                aws.String(lb.scheme),
 			DNSName:               aws.String(lb.dnsName),
 			CanonicalHostedZoneId: aws.String(lbHostedZoneID),
 		})
 	}
 
-	out := &aws_alb.DescribeLoadBalancersOutput{
+	out := &awselb.DescribeLoadBalancersOutput{
 		LoadBalancers: lbs,
 	}
 
-	m.On("DescribeLoadBalancers", &aws_alb.DescribeLoadBalancersInput{
+	m.On("DescribeLoadBalancers", &awselb.DescribeLoadBalancersInput{
 		Names: aws.StringSlice(names),
 	}).Return(out, err)
 }
@@ -106,19 +105,19 @@ func (m *mockELB) mockFindFrontEndElbs(labelValue string, lbDetails []lbDetail, 
 	m.On("FindFrontEndElbs", mock.Anything, labelValue).Return(lbs, err)
 }
 
-func (m *mockELB) DescribeLoadBalancers(input *aws_elb.DescribeLoadBalancersInput) (*aws_elb.DescribeLoadBalancersOutput, error) {
+func (m *mockELB) DescribeLoadBalancers(input *awselb.DescribeLoadBalancersInput) (*awselb.DescribeLoadBalancersOutput, error) {
 	return nil, nil
 }
 
-func (m *mockELB) DescribeTags(input *aws_elb.DescribeTagsInput) (*aws_elb.DescribeTagsOutput, error) {
+func (m *mockELB) DescribeTags(input *awselb.DescribeTagsInput) (*awselb.DescribeTagsOutput, error) {
 	return nil, nil
 }
 
-func (m *mockELB) RegisterInstancesWithLoadBalancer(input *aws_elb.RegisterInstancesWithLoadBalancerInput) (*aws_elb.RegisterInstancesWithLoadBalancerOutput, error) {
+func (m *mockELB) RegisterTargets(input *awselb.RegisterTargetsInput) (*awselb.RegisterTargetsOutput, error) {
 	return nil, nil
 }
 
-func (m *mockELB) DeregisterInstancesFromLoadBalancer(input *aws_elb.DeregisterInstancesFromLoadBalancerInput) (*aws_elb.DeregisterInstancesFromLoadBalancerOutput, error) {
+func (m *mockELB) DeregisterTargets(input *awselb.DeregisterTargetsInput) (*awselb.DeregisterTargetsOutput, error) {
 	return nil, nil
 }
 

--- a/dns/dns_updater_test.go
+++ b/dns/dns_updater_test.go
@@ -266,9 +266,7 @@ func TestRecordSetUpdates(t *testing.T) {
 	}{
 		{
 			"Empty update has no change",
-			controller.IngressEntries{},
-			[]*route53.ResourceRecordSet{},
-			[]*route53.Change{},
+			nil, nil, nil,
 		},
 		{
 			"Add new record",
@@ -326,7 +324,7 @@ func TestRecordSetUpdates(t *testing.T) {
 		},
 		{
 			"Deleting existing record",
-			controller.IngressEntries{},
+			nil,
 			[]*route53.ResourceRecordSet{
 				{
 					Name: aws.String("foo.com."),
@@ -435,7 +433,7 @@ func TestRecordSetUpdates(t *testing.T) {
 				},
 			},
 			nil,
-			[]*route53.Change{},
+			nil,
 		},
 		{
 			"Duplicate hosts are not duplicated in changeset",
@@ -526,7 +524,7 @@ func TestRecordSetUpdates(t *testing.T) {
 					EvaluateTargetHealth: aws.Bool(false),
 				},
 			}},
-			[]*route53.Change{},
+			nil,
 		},
 	}
 
@@ -565,8 +563,8 @@ func TestRecordSetUpdatesWithAddressArguments(t *testing.T) {
 			"Empty update has no change",
 			internalAndExternalFrontends,
 			controller.IngressEntries{},
-			[]*route53.ResourceRecordSet{},
-			[]*route53.Change{},
+			nil,
+			nil,
 		},
 		{
 			"Add new record",
@@ -748,7 +746,7 @@ func TestRecordSetUpdatesWithAddressArguments(t *testing.T) {
 				},
 			},
 			nil,
-			[]*route53.Change{},
+			nil,
 		},
 		{
 			"Duplicate hosts are not duplicated in changeset",
@@ -845,7 +843,7 @@ func TestRecordSetUpdatesWithAddressArguments(t *testing.T) {
 					},
 				},
 			}},
-			[]*route53.Change{},
+			nil,
 		},
 		{
 			"Updates TTL on a CNAME record when it has changed",
@@ -924,8 +922,8 @@ func TestRecordSetUpdatesWithAddressArguments(t *testing.T) {
 				LbScheme:    externalScheme,
 				ServicePort: 80,
 			}},
-			[]*route53.ResourceRecordSet{},
-			[]*route53.Change{},
+			nil,
+			nil,
 		},
 	}
 

--- a/dns/r53/client.go
+++ b/dns/r53/client.go
@@ -35,8 +35,9 @@ type client struct {
 // New creates a route53 client used to interact with aws
 func New(hostedZone string, retries int) Route53Client {
 	config := aws.Config{MaxRetries: aws.Int(retries)}
+	awsSession, _ := session.NewSession()
 	return &client{
-		r53:              route53.New(session.New(), &config),
+		r53:              route53.New(awsSession, &config),
 		hostedZone:       hostedZone,
 		maxRecordChanges: maxRecordChanges,
 	}
@@ -76,7 +77,7 @@ func (dns *client) UpdateRecordSets(changes []*route53.Change) error {
 
 // GetRecords gets a list of DNS records from aws.
 func (dns *client) GetRecords() ([]*route53.ResourceRecordSet, error) {
-	records := []*route53.ResourceRecordSet{}
+	var records []*route53.ResourceRecordSet
 	request := &route53.ListResourceRecordSetsInput{
 		HostedZoneId: aws.String(dns.hostedZone),
 	}

--- a/dns/r53/client_test.go
+++ b/dns/r53/client_test.go
@@ -71,11 +71,11 @@ func TestGetRecords(t *testing.T) {
 	// given
 	client, fake53 := createClient()
 	expectedRecords := []*route53.ResourceRecordSet{
-		&route53.ResourceRecordSet{
+		{
 			Name: aws.String("james.com"),
 			Type: aws.String("A"),
 		},
-		&route53.ResourceRecordSet{
+		{
 			Name: aws.String("james2.com"),
 			Type: aws.String("CNAME"),
 		},

--- a/docker/ingress/Dockerfile
+++ b/docker/ingress/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
-# Install nginx
+# Install NGINX
 
 ENV NGINX_VERSION 1.15.7
 ENV NGINX_SHA256 8f22ea2f6c0e0a221b6ddc02b6428a3ff708e2ad55f9361102b1c9f4142bdf93
@@ -31,7 +31,7 @@ ENV JAEGER_SHA256 21257af93a64fee42c04ca6262d292b2e4e0b7b0660c511db357b32fd42ef5
 COPY build-nginx.sh /tmp
 RUN chmod 755 /tmp/build-nginx.sh
 RUN /tmp/build-nginx.sh
-# For binding to privileged ports in nginx.
+# For binding to privileged ports in NGINX.
 RUN setcap "cap_net_bind_service=+ep" /usr/sbin/nginx
 
 # Setup feed controller

--- a/docker/ingress/build-nginx.sh
+++ b/docker/ingress/build-nginx.sh
@@ -12,7 +12,7 @@ apt-get install --no-install-suggests --no-install-recommends -y \
     libaio1 libaio-dev \
     sudo libssl-dev
 
-echo "--- Downloading nginx and modules"
+echo "--- Downloading NGINX and modules"
 mkdir /tmp/nginx
 cd /tmp/nginx
 curl -O http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
@@ -61,7 +61,7 @@ HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir)
 
 cd /tmp/nginx/nginx-${NGINX_VERSION}
 
-echo "--- Configuring nginx"
+echo "--- Configuring NGINX"
 ./configure \
     --prefix=/nginx \
     --sbin-path=/usr/sbin/nginx \
@@ -87,7 +87,7 @@ echo "--- Configuring nginx"
     --add-module=/tmp/nginx/nginx-module-vts-${VTS_VERSION}\
     --with-http_ssl_module
 
-echo "--- Building nginx"
+echo "--- Building NGINX"
 make
 make install
 

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	aws_elb "github.com/aws/aws-sdk-go/service/elb"
+	awselb "github.com/aws/aws-sdk-go/service/elbv2"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util"
@@ -43,7 +43,7 @@ func New(region string, frontendTagValue string, ingressClassTagValue string, ex
 
 	return &elb{
 		metadata:             ec2metadata.New(session),
-		awsElb:               aws_elb.New(session),
+		awsElb:               awselb.New(session),
 		frontendTagValue:     frontendTagValue,
 		ingressClassTagValue: ingressClassTagValue,
 		region:               region,
@@ -55,7 +55,7 @@ func New(region string, frontendTagValue string, ingressClassTagValue string, ex
 
 // LoadBalancerDetails stores all the elb information we use.
 type LoadBalancerDetails struct {
-	Name         string
+	Arn          string
 	DNSName      string
 	HostedZoneID string
 	Scheme       string
@@ -84,10 +84,10 @@ type initialised struct {
 // ELB interface to allow mocking of real calls to AWS as well as cutting down the methods from the real
 // interface to only the ones we use
 type ELB interface {
-	DescribeLoadBalancers(input *aws_elb.DescribeLoadBalancersInput) (*aws_elb.DescribeLoadBalancersOutput, error)
-	DescribeTags(input *aws_elb.DescribeTagsInput) (*aws_elb.DescribeTagsOutput, error)
-	RegisterInstancesWithLoadBalancer(input *aws_elb.RegisterInstancesWithLoadBalancerInput) (*aws_elb.RegisterInstancesWithLoadBalancerOutput, error)
-	DeregisterInstancesFromLoadBalancer(input *aws_elb.DeregisterInstancesFromLoadBalancerInput) (*aws_elb.DeregisterInstancesFromLoadBalancerOutput, error)
+	DescribeLoadBalancers(input *awselb.DescribeLoadBalancersInput) (*awselb.DescribeLoadBalancersOutput, error)
+	DescribeTags(input *awselb.DescribeTagsInput) (*awselb.DescribeTagsOutput, error)
+	RegisterTargets(input *awselb.RegisterTargetsInput) (*awselb.RegisterTargetsOutput, error)
+	DeregisterTargets(input *awselb.DeregisterTargetsInput) (*awselb.DeregisterTargetsOutput, error)
 }
 
 // EC2Metadata interface to allow mocking of the real calls to AWS
@@ -124,17 +124,17 @@ func (e *elb) attachToFrontEnds() error {
 	registered := 0
 
 	for _, frontend := range clusterFrontEnds {
-		log.Infof("Registering instance %s with elb %s", instance, frontend.Name)
-		_, err = e.awsElb.RegisterInstancesWithLoadBalancer(&aws_elb.RegisterInstancesWithLoadBalancerInput{
-			Instances: []*aws_elb.Instance{
+		log.Infof("Registering instance %s with elb %s", instance, frontend.Arn)
+		_, err = e.awsElb.RegisterTargets(&awselb.RegisterTargetsInput{
+			Targets: []*awselb.TargetDescription{
 				{
-					InstanceId: aws.String(instance),
+					Id: aws.String(instance),
 				}},
-			LoadBalancerName: aws.String(frontend.Name),
+			TargetGroupArn: aws.String(frontend.Arn),
 		})
 
 		if err != nil {
-			return fmt.Errorf("unable to register instance %s with elb %s: %v", instance, frontend.Name, err)
+			return fmt.Errorf("unable to register instance %s with elb %s: %v", instance, frontend.Arn, err)
 		}
 		registered++
 
@@ -160,8 +160,8 @@ func FindFrontEndElbs(awsElb ELB, frontendTagValue string) (map[string]LoadBalan
 func FindFrontEndElbsWithIngressClassName(awsElb ELB, frontendTagValue string, ingressClassValue string) (map[string]LoadBalancerDetails, error) {
 	maxTagQuery := 20
 	// Find the load balancers that are tagged with this cluster name
-	request := &aws_elb.DescribeLoadBalancersInput{}
-	var lbNames []*string
+	request := &awselb.DescribeLoadBalancersInput{}
+	var lbArns []*string
 	allLbs := make(map[string]LoadBalancerDetails)
 
 	for {
@@ -171,14 +171,14 @@ func FindFrontEndElbsWithIngressClassName(awsElb ELB, frontendTagValue string, i
 			return nil, fmt.Errorf("unable to describe load balancers: %v", err)
 		}
 
-		for _, entry := range resp.LoadBalancerDescriptions {
-			allLbs[*entry.LoadBalancerName] = LoadBalancerDetails{
-				Name:         aws.StringValue(entry.LoadBalancerName),
+		for _, entry := range resp.LoadBalancers {
+			allLbs[*entry.LoadBalancerArn] = LoadBalancerDetails{
+				Arn:          aws.StringValue(entry.LoadBalancerArn),
 				DNSName:      aws.StringValue(entry.DNSName),
-				HostedZoneID: aws.StringValue(entry.CanonicalHostedZoneNameID),
+				HostedZoneID: aws.StringValue(entry.CanonicalHostedZoneId),
 				Scheme:       aws.StringValue(entry.Scheme),
 			}
-			lbNames = append(lbNames, entry.LoadBalancerName)
+			lbArns = append(lbArns, entry.LoadBalancerArn)
 		}
 
 		if resp.NextMarker == nil {
@@ -186,12 +186,12 @@ func FindFrontEndElbsWithIngressClassName(awsElb ELB, frontendTagValue string, i
 		}
 
 		// Set the next marker
-		request = &aws_elb.DescribeLoadBalancersInput{
+		request = &awselb.DescribeLoadBalancersInput{
 			Marker: resp.NextMarker,
 		}
 	}
 
-	log.Debugf("Found %d loadbalancers.", len(lbNames))
+	log.Debugf("Found %d loadbalancers.", len(lbArns))
 
 	requiredTags := map[string]string{ElbTag: frontendTagValue}
 
@@ -200,11 +200,11 @@ func FindFrontEndElbsWithIngressClassName(awsElb ELB, frontendTagValue string, i
 	}
 
 	clusterFrontEnds := make(map[string]LoadBalancerDetails)
-	partitions := util.Partition(len(lbNames), maxTagQuery)
+	partitions := util.Partition(len(lbArns), maxTagQuery)
 	for _, partition := range partitions {
-		names := lbNames[partition.Low:partition.High]
-		output, err := awsElb.DescribeTags(&aws_elb.DescribeTagsInput{
-			LoadBalancerNames: names,
+		arns := lbArns[partition.Low:partition.High]
+		output, err := awsElb.DescribeTags(&awselb.DescribeTagsInput{
+			ResourceArns: arns,
 		})
 
 		if err != nil {
@@ -214,8 +214,8 @@ func FindFrontEndElbsWithIngressClassName(awsElb ELB, frontendTagValue string, i
 		// todo cb error out if we already have an internal or public facing elb
 		for _, elbDescription := range output.TagDescriptions {
 			if tagsDoMatch(elbDescription.Tags, requiredTags) {
-				log.Infof("Found frontend elb %s", *elbDescription.LoadBalancerName)
-				lb := allLbs[*elbDescription.LoadBalancerName]
+				log.Infof("Found frontend elb %s", *elbDescription.ResourceArn)
+				lb := allLbs[*elbDescription.ResourceArn]
 				clusterFrontEnds[lb.Scheme] = lb
 			}
 		}
@@ -223,7 +223,7 @@ func FindFrontEndElbsWithIngressClassName(awsElb ELB, frontendTagValue string, i
 	return clusterFrontEnds, nil
 }
 
-func tagsDoMatch(elbTags []*aws_elb.Tag, tagsToMatch map[string]string) bool {
+func tagsDoMatch(elbTags []*awselb.Tag, tagsToMatch map[string]string) bool {
 	matches := 0
 	for name, value := range tagsToMatch {
 		log.Debugf("Checking for %s tag set to %s", name, value)
@@ -241,14 +241,14 @@ func tagsDoMatch(elbTags []*aws_elb.Tag, tagsToMatch map[string]string) bool {
 func (e *elb) Stop() error {
 	var failed = false
 	for _, elb := range e.elbs {
-		log.Infof("Deregistering instance %s with elb %s", e.instanceID, elb.Name)
-		_, err := e.awsElb.DeregisterInstancesFromLoadBalancer(&aws_elb.DeregisterInstancesFromLoadBalancerInput{
-			Instances:        []*aws_elb.Instance{{InstanceId: aws.String(e.instanceID)}},
-			LoadBalancerName: aws.String(elb.Name),
+		log.Infof("Deregistering instance %s with elb %s", e.instanceID, elb.Arn)
+		_, err := e.awsElb.DeregisterTargets(&awselb.DeregisterTargetsInput{
+			Targets:        []*awselb.TargetDescription{{Id: aws.String(e.instanceID)}},
+			TargetGroupArn: aws.String(elb.Arn),
 		})
 
 		if err != nil {
-			log.Warnf("unable to deregister instance %s with elb %s: %v", e.instanceID, elb.Name, err)
+			log.Warnf("unable to deregister instance %s with elb %s: %v", e.instanceID, elb.Arn, err)
 			failed = true
 		}
 	}

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -1,5 +1,5 @@
 /*
-Package elb provides an updater for an ELB frontend to attach nginx to.
+Package elb provides an updater for an ELB frontend to attach NGINX to.
 */
 package elb
 
@@ -18,8 +18,8 @@ import (
 	"github.com/sky-uk/feed/util"
 )
 
-// ElbTag is the tag key used for identifying ELBs to attach to for a cluster.
-const ElbTag = "sky.uk/KubernetesClusterFrontend"
+// FrontendTag is the tag key used for identifying ELBs to attach to for a cluster.
+const FrontendTag = "sky.uk/KubernetesClusterFrontend"
 
 // IngressClassTag is the tag key used for identifying ELBs to attach to for a given ingress controller.
 const IngressClassTag = "sky.uk/KubernetesClusterIngressClass"
@@ -27,7 +27,7 @@ const IngressClassTag = "sky.uk/KubernetesClusterIngressClass"
 // New creates a new ELB frontend
 func New(region string, frontendTagValue string, ingressClassTagValue string, expectedNumber int, drainDelay time.Duration) (controller.Updater, error) {
 	if frontendTagValue == "" {
-		return nil, fmt.Errorf("unable to create ELB updater: missing value for the tag %v", ElbTag)
+		return nil, fmt.Errorf("unable to create ELB updater: missing value for the tag %v", FrontendTag)
 	}
 	if ingressClassTagValue == "" {
 		return nil, fmt.Errorf("unable to create ELB updater: missing value for the tag %v", IngressClassTag)
@@ -36,14 +36,14 @@ func New(region string, frontendTagValue string, ingressClassTagValue string, ex
 	initMetrics()
 	log.Infof("ELB Front end region: %s, cluster: %s, expected frontends: %d, ingress controller: %s", region, frontendTagValue, expectedNumber, ingressClassTagValue)
 
-	session, err := session.NewSession(&aws.Config{Region: &region})
+	awsSession, err := session.NewSession(&aws.Config{Region: &region})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ELB updater: %v", err)
 	}
 
 	return &elb{
-		metadata:             ec2metadata.New(session),
-		awsElb:               awselb.New(session),
+		metadata:             ec2metadata.New(awsSession),
+		awsElb:               awselb.New(awsSession),
 		frontendTagValue:     frontendTagValue,
 		ingressClassTagValue: ingressClassTagValue,
 		region:               region,
@@ -193,7 +193,7 @@ func FindFrontEndElbsWithIngressClassName(awsElb ELB, frontendTagValue string, i
 
 	log.Debugf("Found %d loadbalancers.", len(lbArns))
 
-	requiredTags := map[string]string{ElbTag: frontendTagValue}
+	requiredTags := map[string]string{FrontendTag: frontendTagValue}
 
 	if ingressClassValue != "" {
 		requiredTags[IngressClassTag] = ingressClassValue

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -176,13 +176,13 @@ func TestAttachWithSingleMatchingLoadBalancer(t *testing.T) {
 			{Key: aws.String(frontendTag), Value: aws.String("different cluster")},
 			{Key: aws.String(ingressName), Value: aws.String("different cluster")},
 		}},
-		lbTags{arn: "other elb", tags: []*awselb.Tag{{Key: aws.String("Bannana"), Value: aws.String("Tasty")}}},
+		lbTags{arn: "other elb", tags: []*awselb.Tag{{Key: aws.String("Banana"), Value: aws.String("Tasty")}}},
 	)
 	mockRegisterTargets(mockElb, clusterFrontEnd, instanceID)
 	err := e.Start()
 
 	//when
-	e.Update(controller.IngressEntries{})
+	_ = e.Update(controller.IngressEntries{})
 
 	//then
 	assert.NoError(t, e.Health())
@@ -209,12 +209,12 @@ func TestReportsErrorIfExpectedNotMatched(t *testing.T) {
 			{Key: aws.String(frontendTag), Value: aws.String("different cluster")},
 			{Key: aws.String(ingressNameTag), Value: aws.String("different cluster")},
 		}},
-		lbTags{arn: "other elb", tags: []*awselb.Tag{{Key: aws.String("Bannana"), Value: aws.String("Tasty")}}},
+		lbTags{arn: "other elb", tags: []*awselb.Tag{{Key: aws.String("Banana"), Value: aws.String("Tasty")}}},
 	)
 	mockRegisterTargets(mockElb, clusterFrontEnd, instanceID)
 
 	//when
-	e.Start()
+	_ = e.Start()
 	err := e.Update(controller.IngressEntries{})
 
 	//then
@@ -281,7 +281,7 @@ func TestAttachWithInternalAndInternetFacing(t *testing.T) {
 
 	//when
 	err := e.Start()
-	e.Update(controller.IngressEntries{})
+	_ = e.Update(controller.IngressEntries{})
 
 	//then
 	mockElb.AssertExpectations(t)
@@ -291,11 +291,11 @@ func TestAttachWithInternalAndInternetFacing(t *testing.T) {
 
 func TestErrorGettingMetadata(t *testing.T) {
 	e, _, mockMetadata := setup()
-	mockMetadata.On("GetInstanceIdentityDocument").Return(ec2metadata.EC2InstanceIdentityDocument{}, fmt.Errorf("No metadata for you"))
+	mockMetadata.On("GetInstanceIdentityDocument").Return(ec2metadata.EC2InstanceIdentityDocument{}, fmt.Errorf("no metadata for you"))
 
 	err := e.Update(controller.IngressEntries{})
 
-	assert.EqualError(t, err, "unable to query ec2 metadata service for InstanceId: No metadata for you")
+	assert.EqualError(t, err, "unable to query ec2 metadata service for InstanceId: no metadata for you")
 }
 
 func TestErrorDescribingLoadBalancers(t *testing.T) {
@@ -304,7 +304,7 @@ func TestErrorDescribingLoadBalancers(t *testing.T) {
 	mockInstanceMetadata(mockMetadata, instanceID)
 	mockElb.On("DescribeLoadBalancers", mock.AnythingOfType("*elbv2.DescribeLoadBalancersInput")).Return(&awselb.DescribeLoadBalancersOutput{}, errors.New("oh dear oh dear"))
 
-	e.Start()
+	_ = e.Start()
 	err := e.Update(controller.IngressEntries{})
 
 	assert.EqualError(t, err, "unable to describe load balancers: oh dear oh dear")
@@ -317,7 +317,7 @@ func TestErrorDescribingTags(t *testing.T) {
 	mockLoadBalancers(mockElb, lb{arn: "one"})
 	mockElb.On("DescribeTags", mock.AnythingOfType("*elbv2.DescribeTagsInput")).Return(&awselb.DescribeTagsOutput{}, errors.New("oh dear oh dear"))
 
-	e.Start()
+	_ = e.Start()
 	err := e.Update(controller.IngressEntries{})
 
 	assert.EqualError(t, err, "unable to describe tags: oh dear oh dear")
@@ -334,7 +334,7 @@ func TestNoMatchingElbs(t *testing.T) {
 	mockClusterTags(mockElb, lbTags{arn: loadBalancerArn, tags: []*awselb.Tag{}})
 
 	// when
-	e.Start()
+	_ = e.Start()
 	err := e.Update(controller.IngressEntries{})
 
 	// then
@@ -354,7 +354,7 @@ func TestAttachingWithoutIngressNameTagElbs(t *testing.T) {
 	}})
 
 	// when
-	e.Start()
+	_ = e.Start()
 	err := e.Update(controller.IngressEntries{})
 
 	// then
@@ -374,7 +374,7 @@ func TestAttachingWithoutFrontendTagElbs(t *testing.T) {
 	}})
 
 	// when
-	e.Start()
+	_ = e.Start()
 	err := e.Update(controller.IngressEntries{})
 
 	// then
@@ -448,7 +448,7 @@ func TestDeregistersWithAttachedELBs(t *testing.T) {
 	mockClusterTags(mockElb,
 		lbTags{arn: clusterFrontEnd, tags: defaultTags},
 		lbTags{arn: clusterFrontEnd2, tags: defaultTags},
-		lbTags{arn: "other elb", tags: []*awselb.Tag{{Key: aws.String("Bannana"), Value: aws.String("Tasty")}}},
+		lbTags{arn: "other elb", tags: []*awselb.Tag{{Key: aws.String("Banana"), Value: aws.String("Tasty")}}},
 	)
 	mockRegisterTargets(mockElb, clusterFrontEnd, instanceID)
 	mockRegisterTargets(mockElb, clusterFrontEnd2, instanceID)
@@ -509,8 +509,8 @@ func TestDeRegisterInstanceError(t *testing.T) {
 	mockElb.On("DeregisterTargets", mock.Anything).Return(&awselb.DeregisterTargetsOutput{}, errors.New("no deregister for you"))
 
 	// when
-	e.Start()
-	e.Update(controller.IngressEntries{})
+	_ = e.Start()
+	_ = e.Update(controller.IngressEntries{})
 	err := e.Stop()
 
 	// then
@@ -533,7 +533,7 @@ func TestRetriesUpdateIfFirstAttemptFails(t *testing.T) {
 		&awselb.RegisterTargetsOutput{}, errors.New("no register for you"))
 
 	// when
-	e.Start()
+	_ = e.Start()
 	firstErr := e.Update(controller.IngressEntries{})
 	secondErr := e.Update(controller.IngressEntries{})
 

--- a/elb/status/status.go
+++ b/elb/status/status.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	aws_elb "github.com/aws/aws-sdk-go/service/elb"
+	awselb "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/elb"
 	"github.com/sky-uk/feed/k8s"
@@ -32,7 +32,7 @@ func New(conf Config) (controller.Updater, error) {
 	}
 
 	return &status{
-		awsElb:              aws_elb.New(session),
+		awsElb:              awselb.New(session),
 		frontendTagValue:    conf.FrontendTagValue,
 		ingressNameTagValue: conf.IngressNameTagValue,
 		loadBalancers:       make(map[string]v1.LoadBalancerStatus),

--- a/examples/feed-ingress-deployment-gorb.yml
+++ b/examples/feed-ingress-deployment-gorb.yml
@@ -1,4 +1,4 @@
-# Example deployment for launching feed-ingress, the nginx ingress controller.
+# Example deployment for launching feed-ingress, the NGINX ingress controller.
 #
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -18,7 +18,7 @@ spec:
         app: feed-ingress
     spec:
 
-      # Listen directly on host interface, required so ELBs can contact nginx.
+      # Listen directly on host interface, required so ELBs can contact NGINX.
       hostNetwork: true
 
       # Time to wait for requests to gracefully terminate when updating the deployment.
@@ -67,10 +67,10 @@ spec:
         args:
         - gorb
 
-        # Ingress nginx port that ELBs will direct traffic towards.
+        # Ingress NGINX port that ELBs will direct traffic towards.
         - --ingress-port=80
 
-        # Health port on nginx, used by ELBs to determine health.
+        # Health port on NGINX, used by ELBs to determine health.
         - --ingress-health-port=8081
 
         # Default security whitelist for ingress. Can be overridden with the sky.uk/allow annotation.
@@ -79,10 +79,10 @@ spec:
         # Health port for the controller to respond on.
         - --health-port=12082
 
-        # Log level of nginx. Recommended to leave at error, or set to crit if too much spam.
+        # Log level of NGINX. Recommended to leave at error, or set to crit if too much spam.
         - --nginx-loglevel=error
 
-        # How often to reload nginx if needed. Setting too low can cause 504s from the ELB in the case of heavy
+        # How often to reload NGINX if needed. Setting too low can cause 504s from the ELB in the case of heavy
         # ingress updates.
         - --nginx-update-period=5m
 
@@ -120,7 +120,7 @@ spec:
         # gorb backend healthcheck type
         - --gorb-backend-healthcheck-type=http
 
-        # nginx host ip address to use when the ingress is not in AWS
+        # NGINX host ip address to use when the ingress is not in AWS
         - --gorb-ingress-instance-ip=$(INSTANCEIP)
 
         # LB drain time - time to wait while the load balancer drains requests from feed when stopping. Should be

--- a/examples/feed-ingress-deployment-ssl.yml
+++ b/examples/feed-ingress-deployment-ssl.yml
@@ -1,4 +1,4 @@
-# Example deployment for launching feed-ingress, the nginx ingress controller.
+# Example deployment for launching feed-ingress, the NGINX ingress controller.
 #
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -18,7 +18,7 @@ spec:
         app: feed-ingress
     spec:
 
-      # Listen directly on host interface, required so ELBs can contact nginx.
+      # Listen directly on host interface, required so ELBs can contact NGINX.
       hostNetwork: true
 
       # Time to wait for requests to gracefully terminate when updating the deployment.
@@ -57,13 +57,13 @@ spec:
         args:
         - elb
 
-        # Ingress nginx port that ELBs will direct traffic towards.
+        # Ingress NGINX port that ELBs will direct traffic towards.
         - --ingress-port=8080
 
-        # Ingress nginx port for ssl traffic
+        # Ingress NGINX port for ssl traffic
         - --ingress-https-port=8443
 
-        # Health port on nginx, used by ELBs to determine health.
+        # Health port on NGINX, used by ELBs to determine health.
         - --ingress-health-port=8081
 
         # Default security whitelist for ingress. Can be overridden with the sky.uk/allow annotation.

--- a/feed-ingress/cmd/elb.go
+++ b/feed-ingress/cmd/elb.go
@@ -42,7 +42,7 @@ func init() {
 	elbCmd.Flags().StringVar(&region, "region", defaultRegion,
 		"AWS region for frontend attachment.")
 	elbCmd.Flags().StringVar(&elbFrontendTagValue, "elb-frontend-tag-value", defaultElbFrontendTagValue,
-		"Attach to ELBs tagged with "+elb.ElbTag+"=value. Leave empty to not attach.")
+		"Attach to ELBs tagged with "+elb.FrontendTag+"=value. Leave empty to not attach.")
 	elbCmd.Flags().IntVar(&elbExpectedNumber, "elb-expected-number", defaultElbExpectedNumber,
 		"Expected number of ELBs to attach to. If 0 the controller will not check,"+
 			" otherwise it fails to start if it can't attach to this number.")

--- a/gorb/gorb_test.go
+++ b/gorb/gorb_test.go
@@ -140,7 +140,7 @@ func (h *gorbHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.responsePrimers[h.requestCounter].response != "" {
 		data, _ := json.Marshal(h.responsePrimers[h.requestCounter].response)
-		w.Write(data)
+		_, _ = w.Write(data)
 	}
 	h.requestCounter++
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -1,5 +1,5 @@
 /*
-Package k8s implements a client for communicating with a Kubernetes apiserver. It is intended
+Package k8s implements a client for communicating with a Kubernetes API server. It is intended
 to support an ingress controller, so it is limited to the types needed.
 
 The types are copied from the stable api of the Kubernetes 1.3 release.
@@ -72,7 +72,7 @@ type NamespaceSelector struct {
 	LabelValue string
 }
 
-// New creates a client for the kubernetes apiserver.
+// New creates a client for the kubernetes API server.
 func New(kubeconfig string, resyncPeriod time.Duration) (Client, error) {
 	clientConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -96,7 +96,7 @@ func (c *client) GetIngresses(selector *NamespaceSelector) ([]*v1beta1.Ingress, 
 		return nil, errors.New("namespaces haven't synced yet")
 	}
 
-	allIngresses := []*v1beta1.Ingress{}
+	var allIngresses []*v1beta1.Ingress
 	for _, obj := range c.ingressStore.List() {
 		allIngresses = append(allIngresses, obj.(*v1beta1.Ingress))
 	}
@@ -107,7 +107,7 @@ func (c *client) GetIngresses(selector *NamespaceSelector) ([]*v1beta1.Ingress, 
 
 	supportedNamespaces := supportedNamespaces(selector, toNamespaces(c.namespaceStore.List()))
 
-	filteredIngresses := []*v1beta1.Ingress{}
+	var filteredIngresses []*v1beta1.Ingress
 	for _, ingress := range allIngresses {
 		if ingressInNamespace(ingress, supportedNamespaces) {
 			filteredIngresses = append(filteredIngresses, ingress)
@@ -129,7 +129,7 @@ func supportedNamespaces(selector *NamespaceSelector, namespaces []*v1.Namespace
 		return namespaces
 	}
 
-	filteredNamespaces := []*v1.Namespace{}
+	var filteredNamespaces []*v1.Namespace
 	for _, namespace := range namespaces {
 		if val, ok := namespace.Labels[selector.LabelName]; ok && val == selector.LabelValue {
 			filteredNamespaces = append(filteredNamespaces, namespace)
@@ -179,7 +179,7 @@ func (c *client) GetServices() ([]*v1.Service, error) {
 		return nil, errors.New("services haven't synced yet")
 	}
 
-	services := []*v1.Service{}
+	var services []*v1.Service
 	for _, obj := range c.serviceStore.List() {
 		services = append(services, obj.(*v1.Service))
 	}

--- a/k8s/status/status_test.go
+++ b/k8s/status/status_test.go
@@ -61,7 +61,7 @@ func createIngresses(name, lbScheme string, lbStatus v1.LoadBalancerStatus) cont
 }
 
 func TestGenerateLoadBalancerStatus(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	var tests = []struct {
 		description string
@@ -99,12 +99,12 @@ func TestGenerateLoadBalancerStatus(t *testing.T) {
 	}
 	for _, test := range tests {
 		fmt.Printf("test: %s\n", test.description)
-		assert.Equal(test.expected, GenerateLoadBalancerStatus(test.endpoints))
+		asserter.Equal(test.expected, GenerateLoadBalancerStatus(test.endpoints))
 	}
 }
 
 func TestStatusUnchanged(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	var tests = []struct {
 		description           string
@@ -139,12 +139,12 @@ func TestStatusUnchanged(t *testing.T) {
 	}
 	for _, test := range tests {
 		fmt.Printf("test: %s\n", test.description)
-		assert.Equal(test.expected, statusUnchanged(test.existingIngressStatus, test.newIngressStatus))
+		asserter.Equal(test.expected, statusUnchanged(test.existingIngressStatus, test.newIngressStatus))
 	}
 }
 
 func TestSortLoadBalancerStatus(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	var tests = []struct {
 		description string
@@ -192,12 +192,12 @@ func TestSortLoadBalancerStatus(t *testing.T) {
 	for _, test := range tests {
 		fmt.Printf("test: %s\n", test.description)
 		sortLoadBalancerStatus(test.lbi)
-		assert.Equal(test.expected, test.lbi)
+		asserter.Equal(test.expected, test.lbi)
 	}
 }
 
 func TestUpdate(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	lbs := createDefaultLBs()
 	ingresses := createIngresses(defaultIngressName, defaultLBLabel, v1.LoadBalancerStatus{})
@@ -207,11 +207,11 @@ func TestUpdate(t *testing.T) {
 
 	err := Update(ingresses, lbs, client)
 
-	assert.NoError(err)
+	asserter.NoError(err)
 }
 
 func TestUpdateFails(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	lbs := createDefaultLBs()
 	ingresses := createIngresses(defaultIngressName, defaultLBLabel, v1.LoadBalancerStatus{})
@@ -221,11 +221,11 @@ func TestUpdateFails(t *testing.T) {
 
 	err := Update(ingresses, lbs, client)
 
-	assert.Error(err)
+	asserter.Error(err)
 }
 
 func TestUpdateDoesNotRunWithNoChange(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	lbs := createDefaultLBs()
 	ingresses := createDefaultIngresses()
@@ -233,5 +233,5 @@ func TestUpdateDoesNotRunWithNoChange(t *testing.T) {
 	client := new(fake.FakeClient)
 	client.On("UpdateIngressStatus").Return(errors.New("failed"))
 
-	assert.NoError(Update(ingresses, lbs, client))
+	asserter.NoError(Update(ingresses, lbs, client))
 }

--- a/k8s/watcher_test.go
+++ b/k8s/watcher_test.go
@@ -11,7 +11,7 @@ import (
 const smallWaitTime = time.Millisecond * 50
 
 func TestWatcherUpdates(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	w := newWatcher()
 	defer close(w.updates)
@@ -25,11 +25,11 @@ func TestWatcherUpdates(t *testing.T) {
 	w.updates <- struct{}{}
 	time.Sleep(smallWaitTime)
 
-	assert.Equal(1, called.Get())
+	asserter.Equal(1, called.Get())
 }
 
 func TestBufferedWatcherBuffersUpdates(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	b := newBufferedWatcher(smallWaitTime)
 	defer close(b.updates)
@@ -45,11 +45,11 @@ func TestBufferedWatcherBuffersUpdates(t *testing.T) {
 	}
 	time.Sleep(smallWaitTime * 2)
 
-	assert.Equal(1, timesCalled.Get())
+	asserter.Equal(1, timesCalled.Get())
 }
 
 func TestCombinedWatcherUpdates(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	w1 := newWatcher()
 	w2 := newWatcher()
@@ -66,5 +66,5 @@ func TestCombinedWatcherUpdates(t *testing.T) {
 	w2.updates <- struct{}{}
 	time.Sleep(smallWaitTime)
 
-	assert.Equal(3, called.Get())
+	asserter.Equal(3, called.Get())
 }

--- a/merlin/status/status.go
+++ b/merlin/status/status.go
@@ -6,7 +6,7 @@ package status
 import (
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/k8s"
-	k8s_status "github.com/sky-uk/feed/k8s/status"
+	k8sStatus "github.com/sky-uk/feed/k8s/status"
 	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
@@ -44,7 +44,7 @@ type status struct {
 func (s *status) Start() error {
 	for lbLabel, cname := range s.cnames {
 		if cname != "" {
-			s.loadBalancers[lbLabel] = k8s_status.GenerateLoadBalancerStatus([]string{cname})
+			s.loadBalancers[lbLabel] = k8sStatus.GenerateLoadBalancerStatus([]string{cname})
 		}
 	}
 	return nil
@@ -59,5 +59,5 @@ func (s *status) Health() error {
 }
 
 func (s *status) Update(ingresses controller.IngressEntries) error {
-	return k8s_status.Update(ingresses, s.loadBalancers, s.kubernetesClient)
+	return k8sStatus.Update(ingresses, s.loadBalancers, s.kubernetesClient)
 }

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -30,7 +30,7 @@ type Port struct {
 	Port int
 }
 
-// Conf configuration for nginx
+// Conf configuration for NGINX
 type Conf struct {
 	BinaryLocation               string
 	WorkingDir                   string
@@ -91,7 +91,7 @@ func (n *nginxUpdater) signalRequired() {
 func (n *nginxUpdater) signalIfRequired() {
 	if n.updateRequired.Get() {
 		log.Info("Signalling Nginx to reload configuration")
-		n.nginx.sighup()
+		_ = n.nginx.sighup()
 		n.updateRequired.Set(false)
 	}
 }
@@ -379,12 +379,12 @@ func (n *nginxUpdater) createConfig(entries controller.IngressEntries) ([]byte, 
 
 	n.AccessLogHeaders = n.getNginxLogHeaders()
 	var output bytes.Buffer
-	template := loadBalancerTemplate{
+	lbTemplate := loadBalancerTemplate{
 		Conf:      n.Conf,
 		Servers:   serverEntries,
 		Upstreams: upstreamEntries,
 	}
-	err = tmpl.Execute(&output, template)
+	err = tmpl.Execute(&output, lbTemplate)
 
 	if err != nil {
 		return []byte{}, fmt.Errorf("unable to create nginx config from template: %v", err)
@@ -444,8 +444,6 @@ type locations []*location
 func (l locations) Len() int           { return len(l) }
 func (l locations) Less(i, j int) bool { return l[i].Path < l[j].Path }
 func (l locations) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
-
-type pathSet map[string]bool
 
 func createServerEntries(entries controller.IngressEntries) []*server {
 	hostToNginxEntry := make(map[string]*server)
@@ -571,8 +569,8 @@ func diff(b1, b2 []byte) ([]byte, error) {
 	defer os.Remove(f2.Name())
 	defer f2.Close()
 
-	f1.Write(b1)
-	f2.Write(b2)
+	_, _ = f1.Write(b1)
+	_, _ = f2.Write(b2)
 
 	data, err := exec.Command("diff", "-u", f1.Name(), f2.Name()).CombinedOutput()
 	if len(data) > 0 {

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -29,7 +29,7 @@ http {
     # Track extended virtual host stats.
     vhost_traffic_status_zone shared:vhost_traffic_status:{{ .VhostStatsSharedMemory }}m;
 
-    # Server names hash bucket sizes. Set based on nginx log messages.
+    # Server names hash bucket sizes. Set based on NGINX log messages.
     {{ if gt .ServerNamesHashBucketSize 0 }}server_names_hash_bucket_size {{ .ServerNamesHashBucketSize }};{{ end }}
     {{ if gt .ServerNamesHashMaxSize 0 }}server_names_hash_max_size {{ .ServerNamesHashMaxSize }};{{ end }}
 
@@ -40,7 +40,7 @@ http {
     # Optimize for latency over throughput for persistent connections.
     tcp_nodelay on;
 
-    # Disable nginx version leakage to external clients.
+    # Disable NGINX version leakage to external clients.
     server_tokens off;
 
     {{ if .ClientHeaderBufferSize }}
@@ -108,7 +108,7 @@ http {
 
     # Disable buffering, as we'll be interacting with ELBs with http listeners, which we assume will
     # quickly consume and generate responses and requests.
-    # This should be enabled if nginx will directly serve traffic externally to unknown clients.
+    # This should be enabled if NGINX will directly serve traffic externally to unknown clients.
     proxy_buffering off;
 
     # Don't mess with redirects.

--- a/nginx/nginx_metrics.go
+++ b/nginx/nginx_metrics.go
@@ -31,7 +31,7 @@ func initMetrics() {
 				Namespace:   metrics.PrometheusNamespace,
 				Subsystem:   metrics.PrometheusIngressSubsystem,
 				Name:        "nginx_connections",
-				Help:        "The active number of connections in use by nginx.",
+				Help:        "The active number of connections in use by NGINX.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Gauge)
 
@@ -67,7 +67,7 @@ func initMetrics() {
 				Namespace:   metrics.PrometheusNamespace,
 				Subsystem:   metrics.PrometheusIngressSubsystem,
 				Name:        "nginx_accepts",
-				Help:        "The number of client connections accepted by nginx.",
+				Help:        "The number of client connections accepted by NGINX.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Gauge)
 
@@ -76,7 +76,7 @@ func initMetrics() {
 				Namespace: metrics.PrometheusNamespace,
 				Subsystem: metrics.PrometheusIngressSubsystem,
 				Name:      "nginx_handled",
-				Help: "The number of client connections handled by nginx. Can be less than accepts if connection limit " +
+				Help: "The number of client connections handled by NGINX. Can be less than accepts if connection limit " +
 					"reached.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Gauge)
@@ -86,7 +86,7 @@ func initMetrics() {
 				Namespace: metrics.PrometheusNamespace,
 				Subsystem: metrics.PrometheusIngressSubsystem,
 				Name:      "nginx_requests",
-				Help: "The number of client requests served by nginx. Will be larger than handled if using persistent " +
+				Help: "The number of client requests served by NGINX. Will be larger than handled if using persistent " +
 					"connections.",
 				ConstLabels: metrics.ConstLabels(),
 			})).(prometheus.Gauge)
@@ -96,7 +96,7 @@ func initMetrics() {
 				Namespace:   metrics.PrometheusNamespace,
 				Subsystem:   metrics.PrometheusIngressSubsystem,
 				Name:        "ingress_requests",
-				Help:        "The number of requests proxied by nginx per ingress.",
+				Help:        "The number of requests proxied by NGINX per ingress.",
 				ConstLabels: metrics.ConstLabels(),
 			},
 			ingressRequestsLabelNames,
@@ -107,7 +107,7 @@ func initMetrics() {
 				Namespace:   metrics.PrometheusNamespace,
 				Subsystem:   metrics.PrometheusIngressSubsystem,
 				Name:        "endpoint_requests",
-				Help:        "The number of requests proxied by nginx per endpoint.",
+				Help:        "The number of requests proxied by NGINX per endpoint.",
 				ConstLabels: metrics.ConstLabels(),
 			},
 			endpointRequestsLabelNames,
@@ -167,7 +167,7 @@ type VTSResponses struct {
 	FiveXX  float64 `json:"5xx"`
 }
 
-// VTSMetrics represents the json returned by the vts nginx plugin.
+// VTSMetrics represents the json returned by the VTS NGINX plugin.
 type VTSMetrics struct {
 	Connections   *VTSConnections                      `json:"connections"`
 	FilterZones   map[string]map[string]VTSRequestData `json:"filterZones"`
@@ -180,14 +180,14 @@ func parseAndSetNginxMetrics(statusPort int) error {
 		return err
 	}
 	defer resp.Body.Close()
-	metrics, err := parseStatusBody(resp.Body)
+	vtsMetrics, err := parseStatusBody(resp.Body)
 	if err != nil {
 		return err
 	}
 
-	updateNginxMetrics(metrics)
-	updateIngressMetrics(metrics)
-	updateEndpointMetrics(metrics)
+	updateNginxMetrics(vtsMetrics)
+	updateIngressMetrics(vtsMetrics)
+	updateEndpointMetrics(vtsMetrics)
 
 	return nil
 }
@@ -251,9 +251,9 @@ func updateEndpointMetrics(metrics VTSMetrics) {
 
 func parseStatusBody(body io.Reader) (VTSMetrics, error) {
 	dec := json.NewDecoder(body)
-	var metrics VTSMetrics
-	if err := dec.Decode(&metrics); err != nil {
+	var vtsMetrics VTSMetrics
+	if err := dec.Decode(&vtsMetrics); err != nil {
 		return VTSMetrics{}, err
 	}
-	return metrics, nil
+	return vtsMetrics, nil
 }

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -41,18 +41,18 @@ func healthHandler(pulse Pulse) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := pulse.Health(); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			io.WriteString(w, fmt.Sprintf("%v\n", err))
+			_, _ = io.WriteString(w, fmt.Sprintf("%v\n", err))
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-		io.WriteString(w, "ok\n")
+		_, _ = io.WriteString(w, "ok\n")
 	}
 }
 
 func okHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	io.WriteString(w, "ok\n")
+	_, _ = io.WriteString(w, "ok\n")
 }
 
 const pollInterval = time.Second

--- a/util/cmd/csv_test.go
+++ b/util/cmd/csv_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 func TestSettingCSV(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	csv := CommaSeparatedValues{}
-	csv.Set("first,second,third")
+	_ = csv.Set("first,second,third")
 
-	assert.Equal(CommaSeparatedValues{"first", "second", "third"}, csv)
+	asserter.Equal(CommaSeparatedValues{"first", "second", "third"}, csv)
 }
 
 func TestSettingEmptyCSV(t *testing.T) {
-	assert := assert.New(t)
+	asserter := assert.New(t)
 
 	csv := CommaSeparatedValues{}
-	csv.Set("")
+	_ = csv.Set("")
 
-	assert.Equal(CommaSeparatedValues{}, csv)
+	asserter.Equal(CommaSeparatedValues{}, csv)
 }

--- a/util/slices_test.go
+++ b/util/slices_test.go
@@ -23,23 +23,20 @@ type test struct {
 }
 
 var tests = []test{
-	test{
+	{
 		input: input{sliceLength: 2, size: 1},
-		result: []Range{Range{
-			Low: 0, High: 1,
-		}, Range{
-			Low: 1, High: 2,
-		}},
+		result: []Range{
+			{Low: 0, High: 1},
+			{Low: 1, High: 2},
+		},
 	},
-	test{
+	{
 		input: input{sliceLength: 5, size: 2},
-		result: []Range{Range{
-			Low: 0, High: 2,
-		}, Range{
-			Low: 2, High: 4,
-		}, Range{
-			Low: 4, High: 5,
-		}},
+		result: []Range{
+			{Low: 0, High: 2},
+			{Low: 2, High: 4},
+			{Low: 4, High: 5},
+		},
 	},
 }
 


### PR DESCRIPTION
We need to use the `ELBv2` library for using NLBs. This PR is to upgrade the library in preparation for introducing NLBs.

See individual commits - one contains fixes for IntelliJ warnings throughout the code.

Required by https://github.com/sky-uk/core-infrastructure/issues/3906