### PR TITLE
Ensure nginx is running

### DIFF
--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -299,10 +299,10 @@ func (n *nginxUpdater) Update(entries controller.IngressEntries) error {
 		return fmt.Errorf("unable to update nginx: %v", err)
 	}
 
+	if nginxStartErr := n.ensureNginxRunning(); nginxStartErr != nil {
+		return nginxStartErr
+	}
 	if updated {
-		if nginxStartErr := n.ensureNginxRunning(); nginxStartErr != nil {
-			return nginxStartErr
-		}
 		if n.initialUpdateAttempted.Get() {
 			n.signalRequired()
 		}


### PR DESCRIPTION
This is to make sure that nginx is running even without any ingresses
created.

Required by https://github.com/sky-uk/core-infrastructure/issues/5172