### PR TITLE
Fix incorrect metrics prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@
 # v2.2.1
 * Attach to NLBs using the instance's private IP address rather than the instance ID to allow services to route to a feed instance on
 the same host.  More information can be found here: https://aws.amazon.com/premiumsupport/knowledge-center/target-connection-fails-load-balancer/.
+* [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
 
 # v2.2.0
 * Reintroduce support for deprecated ingress resource annotations
   `sky.uk/frontend-elb-scheme` and `sky.uk/backend-keepalive-seconds`
+* [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
 
 # v2.1.0
-* Added support for AWS Network Load Balancers
-  with the `nlb` subcommand
+* Added support for AWS Network Load Balancers with the `nlb` subcommand
+* [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
 
 # v2.0.0
 * Added support for multiple feed-ingress controllers per cluster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 * [BUGFIX] feed-ingress metrics now have correct prefix of `feed_ingress_` (was `feed_dns_`)
 
 # v2.2.1
+* [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
 * Attach to NLBs using the instance's private IP address rather than the instance ID to allow services to route to a feed instance on
 the same host.  More information can be found here: https://aws.amazon.com/premiumsupport/knowledge-center/target-connection-fails-load-balancer/.
-* [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
 
 # v2.2.0
+* [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
 * Reintroduce support for deprecated ingress resource annotations
   `sky.uk/frontend-elb-scheme` and `sky.uk/backend-keepalive-seconds`
-* [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
 
 # v2.1.0
-* Added support for AWS Network Load Balancers with the `nlb` subcommand
 * [BUG] feed-ingress metrics are prefixed with `feed_dns_` instead of `feed_ingress_`. Fixed in [v2.2.2](#v222)
+* Added support for AWS Network Load Balancers with the `nlb` subcommand
 
 # v2.0.0
 * Added support for multiple feed-ingress controllers per cluster

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.2.2
+* [BUGFIX] feed-ingress metrics now have correct prefix of `feed_ingress_` (was `feed_dns_`)
+
 # v2.2.1
 * Attach to NLBs using the instance's private IP address rather than the instance ID to allow services to route to a feed instance on
 the same host.  More information can be found here: https://aws.amazon.com/premiumsupport/knowledge-center/target-connection-fails-load-balancer/.

--- a/alb/alb_metrics.go
+++ b/alb/alb_metrics.go
@@ -12,7 +12,7 @@ var attachedFrontendGauge prometheus.Gauge
 
 func initMetrics() {
 	once.Do(func() {
-		attachedFrontendGauge = metrics.RegisterNewDefaultGauge("alb_frontends_attached",
-			"The total number of ALB frontends attached to")
+		attachedFrontendGauge = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem,
+			"alb_frontends_attached", "The total number of ALB frontends attached to")
 	})
 }

--- a/dns/dns_metrics.go
+++ b/dns/dns_metrics.go
@@ -13,13 +13,14 @@ var updateCount, failedCount, skippedCount prometheus.Counter
 
 func initMetrics() {
 	once.Do(func() {
-		recordsGauge = metrics.RegisterNewDefaultGauge("route53_records",
-			"The current number of records.")
-		updateCount = metrics.RegisterNewDefaultCounter("route53_updates",
-			"The number of record updates to Route53.")
-		failedCount = metrics.RegisterNewDefaultCounter("route53_failures",
-			"The number of failed updates to route53.")
-		skippedCount = metrics.RegisterNewDefaultCounter("skipped_ingress_entries",
+		recordsGauge = metrics.RegisterNewDefaultGauge(metrics.PrometheusDNSSubsystem,
+			"route53_records", "The current number of records.")
+		updateCount = metrics.RegisterNewDefaultCounter(metrics.PrometheusDNSSubsystem,
+			"route53_updates", "The number of record updates to Route53.")
+		failedCount = metrics.RegisterNewDefaultCounter(metrics.PrometheusDNSSubsystem,
+			"route53_failures", "The number of failed updates to route53.")
+		skippedCount = metrics.RegisterNewDefaultCounter(metrics.PrometheusDNSSubsystem,
+			"skipped_ingress_entries",
 			"The number of ingress entries skipped by feed-dns, such as being outside of the Route53 hosted zone.")
 	})
 }

--- a/elb/elb_metrics.go
+++ b/elb/elb_metrics.go
@@ -13,7 +13,7 @@ var attachedFrontendGauge prometheus.Gauge
 
 func initMetrics() {
 	once.Do(func() {
-		attachedFrontendGauge = metrics.RegisterNewDefaultGauge("frontends_attached",
-			"The total number of frontends attached")
+		attachedFrontendGauge = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem,
+			"frontends_attached", "The total number of frontends attached")
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	golang.org/x/net v0.0.0-20191101175033-0deb6923b6d9 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191104094858-e8c54fb511f6 // indirect
-	golang.org/x/tools v0.0.0-20191101200257-8dbcdeb83d3f // indirect
+	golang.org/x/tools v0.0.0-20191113055240-e33b02e76616 // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	google.golang.org/api v0.9.0 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect

--- a/go.sum
+++ b/go.sum
@@ -415,6 +415,8 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c h1:IGkKhmfzcztjm6gYkykvu/N
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191101200257-8dbcdeb83d3f h1:+QO45yvqhfD79HVNFPAgvstYLFye8zA+rd0mHFsGV9s=
 golang.org/x/tools v0.0.0-20191101200257-8dbcdeb83d3f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191113055240-e33b02e76616 h1:ZWRqtkwG40JP3u51g3qbIpxQuZICFL5shyGxgnxUhF0=
+golang.org/x/tools v0.0.0-20191113055240-e33b02e76616/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/gorb/gorb_metrics.go
+++ b/gorb/gorb_metrics.go
@@ -13,7 +13,7 @@ var attachedFrontendGauge prometheus.Gauge
 
 func initMetrics() {
 	once.Do(func() {
-		attachedFrontendGauge = metrics.RegisterNewDefaultGauge("gorb_frontends_attached",
-			"The total number of frontends attached to Gorb")
+		attachedFrontendGauge = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem,
+			"gorb_frontends_attached", "The total number of frontends attached to Gorb")
 	})
 }

--- a/nginx/nginx_metrics.go
+++ b/nginx/nginx_metrics.go
@@ -26,39 +26,39 @@ var endpointBytesLabelNames = []string{"name", "endpoint", "direction"}
 
 func initMetrics() {
 	once.Do(func() {
-		connections = metrics.RegisterNewDefaultGauge("nginx_connections",
+		connections = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem, "nginx_connections",
 			"The active number of connections in use by NGINX.")
-		waitingConnections = metrics.RegisterNewDefaultGauge("nginx_connections_waiting",
+		waitingConnections = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem, "nginx_connections_waiting",
 			"The number of idle connections.")
-		writingConnections = metrics.RegisterNewDefaultGauge("nginx_connections_writing",
+		writingConnections = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem, "nginx_connections_writing",
 			"The number of connections writing data.")
-		readingConnections = metrics.RegisterNewDefaultGauge("nginx_connections_reading",
+		readingConnections = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem, "nginx_connections_reading",
 			"The number of connections reading data.")
-		totalAccepts = metrics.RegisterNewDefaultGauge("nginx_accepts",
+		totalAccepts = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem, "nginx_accepts",
 			"The number of client connections accepted by NGINX. "+
 				"For implementation reasons, this counter is a gauge.")
-		totalHandled = metrics.RegisterNewDefaultGauge("nginx_handled",
+		totalHandled = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem, "nginx_handled",
 			"The number of client connections handled by NGINX. "+
 				"Can be less than accepts if connection limit reached. "+
 				"For implementation reasons, this counter is a gauge.")
-		totalRequests = metrics.RegisterNewDefaultGauge("nginx_requests",
+		totalRequests = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem, "nginx_requests",
 			"The number of client requests served by NGINX. "+
 				"Will be larger than handled if using persistent connections. "+
 				"For implementation reasons, this counter is a gauge.")
-		ingressRequests = metrics.RegisterNewDefaultGaugeVec("ingress_requests",
+		ingressRequests = metrics.RegisterNewDefaultGaugeVec(metrics.PrometheusIngressSubsystem, "ingress_requests",
 			"The number of requests proxied by NGINX per ingress. "+
 				"For implementation reasons, this counter is a gauge.",
 			ingressRequestsLabelNames)
-		endpointRequests = metrics.RegisterNewDefaultGaugeVec("endpoint_requests",
+		endpointRequests = metrics.RegisterNewDefaultGaugeVec(metrics.PrometheusIngressSubsystem, "endpoint_requests",
 			"The number of requests proxied by NGINX per endpoint. "+
 				"For implementation reasons, this counter is a gauge.",
 			endpointRequestsLabelNames)
-		ingressBytes = metrics.RegisterNewDefaultGaugeVec("ingress_bytes",
+		ingressBytes = metrics.RegisterNewDefaultGaugeVec(metrics.PrometheusIngressSubsystem, "ingress_bytes",
 			"The number of bytes sent or received by a client to this ingress. "+
 				"Direction is 'in' for bytes received from a client, 'out' for bytes sent to a client. "+
 				"For implementation reasons, this counter is a gauge.",
 			ingressBytesLabelNames)
-		endpointBytes = metrics.RegisterNewDefaultGaugeVec("endpoint_bytes",
+		endpointBytes = metrics.RegisterNewDefaultGaugeVec(metrics.PrometheusIngressSubsystem, "endpoint_bytes",
 			"The number of bytes sent or received by this endpoint. "+
 				"Direction is 'in' for bytes received from the endpoint, 'out' for bytes sent to the endpoint. "+
 				"For implementation reasons, this counter is a gauge.",

--- a/nlb/nlb_metrics.go
+++ b/nlb/nlb_metrics.go
@@ -13,7 +13,7 @@ var attachedFrontendGauge prometheus.Gauge
 
 func initMetrics() {
 	once.Do(func() {
-		attachedFrontendGauge = metrics.RegisterNewDefaultGauge("frontends_attached",
-			"The total number of frontends attached")
+		attachedFrontendGauge = metrics.RegisterNewDefaultGauge(metrics.PrometheusIngressSubsystem,
+			"frontends_attached", "The total number of frontends attached")
 	})
 }

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -131,16 +131,9 @@ func AddHealthMetrics(pulse Pulse, prometheusSubsystem string) {
 }
 
 func createUnhealthyCounter(subsystem string) prometheus.Counter {
-	unhealthyCounter := prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: subsystem,
-		Name:      "unhealthy_time",
-		Help: fmt.Sprintf("The number of seconds %s-%s has been unhealthy.",
-			metrics.PrometheusNamespace, subsystem),
-		ConstLabels: metrics.ConstLabels(),
-	})
-	prometheus.MustRegister(unhealthyCounter)
-	return unhealthyCounter
+	return metrics.RegisterNewDefaultCounter(subsystem, "unhealthy_time",
+		fmt.Sprintf("The number of seconds %s-%s has been unhealthy.",
+			metrics.PrometheusNamespace, subsystem))
 }
 
 // AddMetricsPusher starts a periodic push of metrics to a prometheus pushgateway.

--- a/util/metrics/prometheus.go
+++ b/util/metrics/prometheus.go
@@ -44,20 +44,20 @@ func SetConstLabels(l prometheus.Labels) {
 	constLabels = l
 }
 
-func gaugeOpts(name string, help string) prometheus.GaugeOpts {
+func gaugeOpts(subsystem, name, help string) prometheus.GaugeOpts {
 	return prometheus.GaugeOpts{
 		Namespace:   PrometheusNamespace,
-		Subsystem:   PrometheusDNSSubsystem,
+		Subsystem:   subsystem,
 		Name:        name,
 		Help:        help,
 		ConstLabels: ConstLabels(),
 	}
 }
 
-func counterOpts(name string, help string) prometheus.CounterOpts {
+func counterOpts(subsystem, name, help string) prometheus.CounterOpts {
 	return prometheus.CounterOpts{
 		Namespace:   PrometheusNamespace,
-		Subsystem:   PrometheusDNSSubsystem,
+		Subsystem:   subsystem,
 		Name:        name,
 		Help:        help,
 		ConstLabels: ConstLabels(),
@@ -73,16 +73,16 @@ func register(collector prometheus.Collector, name string) prometheus.Collector 
 }
 
 // RegisterNewDefaultGauge creates and registers a named Gauge with default options
-func RegisterNewDefaultGauge(name string, help string) prometheus.Gauge {
-	return register(prometheus.NewGauge(gaugeOpts(name, help)), name).(prometheus.Gauge)
+func RegisterNewDefaultGauge(subsystem, name, help string) prometheus.Gauge {
+	return register(prometheus.NewGauge(gaugeOpts(subsystem, name, help)), name).(prometheus.Gauge)
 }
 
 // RegisterNewDefaultGaugeVec creates and registers a named GaugeVec with default options
-func RegisterNewDefaultGaugeVec(name string, help string, labelNames []string) *prometheus.GaugeVec {
-	return register(prometheus.NewGaugeVec(gaugeOpts(name, help), labelNames), name).(*prometheus.GaugeVec)
+func RegisterNewDefaultGaugeVec(subsystem, name, help string, labelNames []string) *prometheus.GaugeVec {
+	return register(prometheus.NewGaugeVec(gaugeOpts(subsystem, name, help), labelNames), name).(*prometheus.GaugeVec)
 }
 
 // RegisterNewDefaultCounter creates and registers a named Counter with default options
-func RegisterNewDefaultCounter(name string, help string) prometheus.Counter {
-	return register(prometheus.NewCounter(counterOpts(name, help)), name).(prometheus.Counter)
+func RegisterNewDefaultCounter(subsystem, name, help string) prometheus.Counter {
+	return register(prometheus.NewCounter(counterOpts(subsystem, name, help)), name).(prometheus.Counter)
 }


### PR DESCRIPTION
All metrics were being prefixed with `feed_dns_` since https://github.com/sky-uk/feed/commit/d3824d1b81b2baa211ff306ea50dfb08f9eb9fc5#diff-d0c5f4f4783e272c16b0fae89e62ce6f

Added missing assertion for metric `subsystem` to unit tests.