### PR TITLE
Handle receiving 0 ingresses and prevent http 404s

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -177,23 +177,40 @@ func (c *controller) updateIngresses() (err error) {
 		}
 	}()
 
+	// Get ingresses
 	var ingresses []*v1beta1.Ingress
+
 	if c.namespaceSelector == nil {
 		ingresses, err = c.client.GetAllIngresses()
 	} else {
 		ingresses, err = c.client.GetIngresses(c.namespaceSelector)
 	}
+
 	log.Infof("Found %d ingresses", len(ingresses))
+
 	if err != nil {
 		return err
 	}
+
+	if len(ingresses) == 0 {
+		return errors.New("found 0 ingresses")
+	}
+
+	// Get services
 	services, err := c.client.GetServices()
+
 	if err != nil {
 		return err
 	}
 
-	serviceMap := serviceNamesToClusterIPs(services)
+	log.Infof("Found %d services", len(services))
 
+	if len(services) == 0 {
+		return errors.New("found 0 services")
+	}
+
+	// Combine ingresses and services to create Ingress Entries
+	serviceMap := serviceNamesToClusterIPs(services)
 	var skipped []string
 	var entries []IngressEntry
 	for _, ingress := range ingresses {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -186,7 +186,7 @@ func (c *controller) updateIngresses() (err error) {
 		ingresses, err = c.client.GetIngresses(c.namespaceSelector)
 	}
 
-	log.Infof("Found %d ingresses", len(ingresses))
+	log.Debugf("Found %d ingresses", len(ingresses))
 
 	if err != nil {
 		return err
@@ -203,11 +203,13 @@ func (c *controller) updateIngresses() (err error) {
 		return err
 	}
 
-	log.Infof("Found %d services", len(services))
+	log.Debugf("Found %d services", len(services))
 
 	if len(services) == 0 {
 		return errors.New("found 0 services")
 	}
+
+	log.Infof("Found %d ingresses and %d services", len(ingresses), len(services))
 
 	// Combine ingresses and services to create Ingress Entries
 	serviceMap := serviceNamesToClusterIPs(services)

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -71,3 +71,8 @@ func (e IngressEntry) validate() error {
 func (e IngressEntry) NamespaceName() string {
 	return fmt.Sprintf("%s/%s", e.Namespace, e.Name)
 }
+
+func (e IngressEntry) String() string {
+	return fmt.Sprintf("IngressEntry[Namespace=%s,Name=%s,Host=%s,Path=%s,ServiceAddress=%s,ServicePort=%d]",
+		e.Namespace, e.Name, e.Host, e.Path, e.ServiceAddress, e.ServicePort)
+}

--- a/nginx/fake_graceful_nginx.py
+++ b/nginx/fake_graceful_nginx.py
@@ -11,7 +11,8 @@ def sigquit_handler(sig, frame):
 
 # Can't do anything in this handler - python libs are not thread safe, so not safe to call e.g. print.
 def sighup_handler(sig, frame):
-    pass
+    with open(startup_marker_file_name, 'w') as f:
+        f.write('reloaded!')
 
 print('Running {}'.format(str(sys.argv)))
 
@@ -30,7 +31,7 @@ signal.signal(signal.SIGQUIT, sigquit_handler)
 signal.signal(signal.SIGHUP, sighup_handler)
 signal.pause
 
-startup_marker_file_name = str.join('/', sys.argv[2].split('/')[:-1]) + '/nginx-started'
+startup_marker_file_name = str.join('/', sys.argv[2].split('/')[:-1]) + '/nginx-log'
 with open(startup_marker_file_name, 'w') as f:
     f.write('started!')
 

--- a/nginx/nginx_metrics.go
+++ b/nginx/nginx_metrics.go
@@ -64,7 +64,8 @@ func initMetrics() {
 				"Direction is 'in' for bytes received from the endpoint, 'out' for bytes sent to the endpoint. "+
 				"For implementation reasons, this counter is a gauge.",
 			endpointBytesLabelNames)
-		reloads = metrics.RegisterNewDefaultCounter("reloads", "Count of Nginx configuration reloads")
+		reloads = metrics.RegisterNewDefaultCounter(metrics.PrometheusIngressSubsystem, "reloads",
+			"Count of Nginx configuration reloads")
 	})
 }
 
@@ -187,6 +188,6 @@ func parseStatusBody(body io.Reader) (VTSMetrics, error) {
 	return vtsMetrics, nil
 }
 
-func incrementReloadMetric(){
+func incrementReloadMetric() {
 	reloads.Inc()
 }

--- a/nginx/nginx_metrics.go
+++ b/nginx/nginx_metrics.go
@@ -19,6 +19,7 @@ var once sync.Once
 var connections, waitingConnections, writingConnections, readingConnections prometheus.Gauge
 var totalAccepts, totalHandled, totalRequests prometheus.Gauge
 var ingressRequests, endpointRequests, ingressBytes, endpointBytes *prometheus.GaugeVec
+var reloads prometheus.Counter
 var ingressRequestsLabelNames = []string{"host", "path", "code"}
 var endpointRequestsLabelNames = []string{"name", "endpoint", "code"}
 var ingressBytesLabelNames = []string{"host", "path", "direction"}
@@ -63,6 +64,7 @@ func initMetrics() {
 				"Direction is 'in' for bytes received from the endpoint, 'out' for bytes sent to the endpoint. "+
 				"For implementation reasons, this counter is a gauge.",
 			endpointBytesLabelNames)
+		reloads = metrics.RegisterNewDefaultCounter("reloads", "Count of Nginx configuration reloads")
 	})
 }
 
@@ -183,4 +185,8 @@ func parseStatusBody(body io.Reader) (VTSMetrics, error) {
 		return VTSMetrics{}, err
 	}
 	return vtsMetrics, nil
+}
+
+func incrementReloadMetric(){
+	reloads.Inc()
 }

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/sky-uk/feed/controller"
 	"github.com/sky-uk/feed/util/metrics"
@@ -113,17 +114,83 @@ func TestNginxStartedAfterFirstUpdate(t *testing.T) {
 	}})
 	assert.NoError(t, err)
 
-	assert.True(t, nginxStartedSuccessfully(tmpDir))
+	assert.True(t, nginxHasStarted(tmpDir))
 }
 
-func nginxStartedSuccessfully(nginxDir string) bool {
-	filename := fmt.Sprintf("%s/nginx-started", nginxDir)
+func TestNginxDoesNotStartWithZeroIngresses(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	defer os.Remove(tmpDir)
+	lb := newUpdater(tmpDir)
+
+	lb.Start()
+
+	assert.EqualError(t, lb.Update([]controller.IngressEntry{}), "nginx update has been called with 0 entries")
+	assert.False(t, nginxHasStarted(tmpDir))
+}
+
+func TestNginxDoesNotReloadWithZeroIngresses(t *testing.T) {
+	tmpDir := setupWorkDir(t)
+	defer os.Remove(tmpDir)
+	lb := newUpdater(tmpDir)
+
+	lb.Start()
+	err := lb.Update([]controller.IngressEntry{{
+		Host: "james.com",
+	}})
+	assert.NoError(t, err)
+	assert.True(t, nginxHasStarted(tmpDir))
+
+	err = lb.Update([]controller.IngressEntry{})
+	assert.EqualError(t, err, "nginx update has been called with 0 entries")
+	time.Sleep(time.Second * 2)
+	assert.False(t, nginxHasReloaded(tmpDir))
+}
+
+func TestReloadMetricIsIncremented(t *testing.T) {
+	assert := assert.New(t)
+	tmpDir := setupWorkDir(t)
+	defer os.Remove(tmpDir)
+
+	ts := stubHealthPort()
+	defer ts.Close()
+
+	conf := newConf(tmpDir, fakeNginx)
+	conf.HealthPort = getPort(ts)
+	lb := newNginxWithConf(conf)
+
+
+	lb.Start()
+	err := lb.Update([]controller.IngressEntry{{
+		Host: "james.com",
+	}})
+	assert.NoError(err)
+	assert.True(nginxHasStarted(tmpDir))
+
+	err = lb.Update([]controller.IngressEntry{{
+		Host: "bob.com",
+	}})
+	time.Sleep(time.Second * 2)
+
+	assert.True(nginxHasReloaded(tmpDir))
+	assert.Equal(float64(1), testutil.ToFloat64(reloads))
+}
+
+func nginxHasStarted(tmpDir string) bool {
+	return nginxLogEquals(tmpDir, "started!")
+}
+
+func nginxHasReloaded(tmpDir string) bool {
+	return nginxLogEquals(tmpDir, "reloaded!")
+}
+
+func nginxLogEquals(nginxDir string, message string) bool {
+	filename := fmt.Sprintf("%s/nginx-log", nginxDir)
 	file, _ := os.Open(filename)
 	defer file.Close()
 
-	buf := make([]byte, 8)
+	buf := make([]byte, len(message))
 	file.Read(buf)
-	return string(buf) == "started!"
+	return string(buf) == message
 }
 
 func TestUnhealthyIfHealthPortIsNotUp(t *testing.T) {
@@ -434,7 +501,9 @@ func TestNginxConfig(t *testing.T) {
 		lb := newNginxWithConf(test.conf)
 
 		assert.NoError(lb.Start())
-		err := lb.Update(controller.IngressEntries{})
+		err := lb.Update([]controller.IngressEntry{{
+			Host: "james.com",
+		}})
 		assert.NoError(err)
 
 		config, err := ioutil.ReadFile(tmpDir + "/nginx.conf")
@@ -741,6 +810,62 @@ func TestNginxIngressEntries(t *testing.T) {
 				"        }\n" +
 				"    }",
 			},
+		},
+		{
+			"Duplicate host/path entries are ignored, the first one is kept order by Service",
+			defaultConf,
+			[]controller.IngressEntry{
+				{
+					Namespace:         "core",
+					Name:              "ingress",
+					Host:              "foo-0.com",
+					Path:              "/",
+					ServiceAddress:    "service-2",
+					ServicePort:       8080,
+					Allow:             []string{"10.82.0.0/16"},
+					CreationTimestamp: time.Now().Add(-1 * time.Minute),
+				},
+				{
+					Namespace:         "core",
+					Name:              "ingress",
+					Host:              "foo-0.com",
+					Path:              "/",
+					ServiceAddress:    "service-1",
+					ServicePort:       8080,
+					Allow:             []string{"10.82.0.0/16"},
+					CreationTimestamp: time.Now(),
+				},
+			},
+			nil,
+			[]string{"proxy_pass http://core.service-1.8080"},
+		},
+		{
+			"Duplicate host/path entries are ignored, the first one is kept order by Port",
+			defaultConf,
+			[]controller.IngressEntry{
+				{
+					Namespace:         "core",
+					Name:              "ingress",
+					Host:              "foo-0.com",
+					Path:              "/",
+					ServiceAddress:    "service",
+					ServicePort:       2,
+					Allow:             []string{"10.82.0.0/16"},
+					CreationTimestamp: time.Now().Add(-1 * time.Minute),
+				},
+				{
+					Namespace:         "core",
+					Name:              "ingress",
+					Host:              "foo-0.com",
+					Path:              "/",
+					ServiceAddress:    "service",
+					ServicePort:       1,
+					Allow:             []string{"10.82.0.0/16"},
+					CreationTimestamp: time.Now(),
+				},
+			},
+			nil,
+			[]string{"proxy_pass http://core.service.1"},
 		},
 		{
 			"Check path slashes are added correctly",

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -158,7 +158,6 @@ func TestReloadMetricIsIncremented(t *testing.T) {
 	conf.HealthPort = getPort(ts)
 	lb := newNginxWithConf(conf)
 
-
 	lb.Start()
 	err := lb.Update([]controller.IngressEntry{{
 		Host: "james.com",


### PR DESCRIPTION
Don't start Nginx or reload the config if Update is called with 0
ingresses.  Instead, return an error and let the controller handle it.
This fixes an issue where the k8s client returns 0 ingresses during
startup and Nginx then returns http 404s for all ingresses.

Fix for the sorting of ingresses when filtering for unique entries.
This fixes an issue with flapping ingresses when the same path is
defined for different services under the same host. This flapping
was causing Nginx to reload frequently which is disruptive.  We now
include service and port in the sorting.

Add a metric for Nginx config reloads.

Required by https://github.com/sky-uk/core-infrastructure/issues/5657