### PR TITLE
Remove http binding by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v3.0.0
+* Breaking change 
+  By default feed will not bind http port on 8080 if `--ingress-port=XXXX` is not provided   
+  * Remove http binding by default (#216)
+ 
+# v2.3.0
+* Support IP and Instance TargetGroup attachments (#214)
+
 # v2.2.3
 * [BUGFIX] Handle receiving 0 ingresses from the k8s client by not reloading the Nginx config
 * [BUGFIX] Improve sorting when choosing which duplicate ingresses to keep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.0.0
 * Breaking change 
-  By default feed will not bind http port on 8080 if `--ingress-port=XXXX` is not provided   
+  Feed will not bind port http 8080 by default, unless `--ingress-port=XXXX` is provided   
   * Remove http binding by default (#216)
  
 # v2.3.0

--- a/feed-ingress/cmd/common.go
+++ b/feed-ingress/cmd/common.go
@@ -56,10 +56,7 @@ func runCmd(appender appendIngressUpdaters) {
 }
 
 func createIngressUpdaters(kubernetesClient k8s.Client, appender appendIngressUpdaters) ([]controller.Updater, error) {
-	nginxConfig.Ports = []nginx.Port{{Name: "http", Port: ingressPort}}
-	if ingressHTTPSPort != unset {
-		nginxConfig.Ports = append(nginxConfig.Ports, nginx.Port{Name: "https", Port: ingressHTTPSPort})
-	}
+	nginxConfig.Ports = createPortsConfig(ingressPort, ingressHTTPSPort)
 
 	nginxConfig.HealthPort = ingressHealthPort
 	nginxConfig.SSLPath = nginxSSLPath
@@ -76,6 +73,21 @@ func createIngressUpdaters(kubernetesClient k8s.Client, appender appendIngressUp
 		return nil, err
 	}
 	return updaters, nil
+}
+
+func createPortsConfig(ingressPort int, ingressHTTPSPort int) []nginx.Port {
+	var ports = []nginx.Port{}
+	if ingressPort != unset {
+		ports = append(ports, nginx.Port{Name: "http", Port: ingressPort})
+	}
+	if ingressHTTPSPort != unset {
+		ports = append(ports, nginx.Port{Name: "https", Port: ingressHTTPSPort})
+	}
+
+	if len(ports) == 0 {
+		log.Fatal("Error http or https port must be provided,(--ingress-port=XXXX or --ingress-https-port=XXXX) exiting")
+	}
+	return ports
 }
 
 func parseNamespaceSelector(nameValueStr string) (*k8s.NamespaceSelector, error) {

--- a/feed-ingress/cmd/common_test.go
+++ b/feed-ingress/cmd/common_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/sky-uk/feed/nginx"
+)
+
+func TestCreatePortsConfigWithoutPorts(t *testing.T) {
+	if os.Getenv("BE_CRASHER") == "1" {
+		createPortsConfig(unset, unset)
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestCreatePortsConfigWithoutPorts")
+	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
+}
+
+func TestCreatePortsConfigWithOnePort(t *testing.T) {
+	ports := createPortsConfig(1, unset)
+	expectedPorts := []nginx.Port{nginx.Port{Name: "http", Port: 1}}
+	portsHTTPS := createPortsConfig(unset, 2)
+	expectedPortsHTTPS := []nginx.Port{nginx.Port{Name: "https", Port: 2}}
+
+	assert.Equal(t, expectedPorts, ports, "they should be equal")
+	assert.Equal(t, expectedPortsHTTPS, portsHTTPS, "they should be equal")
+}
+
+func TestCreatePortsConfigWithPorts(t *testing.T) {
+	ports := createPortsConfig(1, 2)
+	expectedPorts := []nginx.Port{nginx.Port{Name: "http", Port: 1}, nginx.Port{Name: "https", Port: 2}}
+
+	assert.Equal(t, expectedPorts, ports, "they should be equal")
+}

--- a/feed-ingress/cmd/common_test.go
+++ b/feed-ingress/cmd/common_test.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sky-uk/feed/nginx"
 )

--- a/feed-ingress/cmd/root.go
+++ b/feed-ingress/cmd/root.go
@@ -58,7 +58,7 @@ const (
 	unset = -1
 
 	defaultResyncPeriod      = time.Minute * 15
-	defaultIngressPort       = 8080
+	defaultIngressPort       = unset
 	defaultIngressHTTPSPort  = unset
 	defaultIngressHealthPort = 8081
 	defaultIngressAllow      = "0.0.0.0/0"


### PR DESCRIPTION
Remove http binding by default, feed should be able to run with https only to avoid using an extra port.