### PR TITLE
Fix X-Forwarded-Host to correctly forward client Host header

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -97,7 +97,7 @@ http {
         '' $server_port;
     }
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Host $host:$frontend_port;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $frontend_scheme;
     proxy_set_header X-Original-URI $request_uri;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
The existing behavior is flawed in that it doesn't preserve the original
client's `Host` header as expected. Instead it uses nginx's own internal
host (which matches the server name), then it always appends the port.

To match the de facto convention of X-Forwarded-Host, we should simply
preserve the original client's `Host`.

An example of where this breaks is the docker registry:

1. Client tries to push to registry.com/my-repo/image:v1 via feed
ingress, hitting the blob upload endpoint
2. The registry gets `X-Forwarded-Host=registry.com:443`, so it
interprets itself as being `registry.com:443` rather than `registry.com`.
3. The registry then sends a `Location` header back with
`registry.com:443/my-repo/image` to push the layers
4. Client looks up credentials for `registry.com:443` which fails, and
so the push fails.

I'm not quite sure why we did it originally this way (constructing our
own host:port) - so not sure whether this would break anything. But I
can't think of any problems this change would cause.