### PR TITLE
Account for concurrent status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.1.4
+* [BUGFIX] Account for concurrent status updates (#219)
+
 # v3.1.3
 * [BUGFIX] Trim whitespace from sky.uk/allow entries (#223)
 

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -11,7 +11,9 @@ import (
 	"sync"
 	"time"
 
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	clientV1Beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	log "github.com/sirupsen/logrus"
@@ -251,8 +253,39 @@ func (c *client) UpdateIngressStatus(ingress *v1beta1.Ingress) error {
 	}
 
 	currentIng.Status.LoadBalancer.Ingress = ingress.Status.LoadBalancer.Ingress
+	return c.updateIngressAndHandleConflicts(ingressClient, currentIng)
+}
 
-	_, err = ingressClient.UpdateStatus(currentIng)
+func (c *client) updateIngressAndHandleConflicts(ingressClient clientV1Beta1.IngressInterface, ingress *v1beta1.Ingress) error {
+	_, err := ingressClient.UpdateStatus(ingress)
 
-	return err
+	switch {
+	case k8errors.IsConflict(err):
+		updatedIng, getErr := ingressClient.Get(ingress.Name, metav1.GetOptions{})
+		if getErr == nil && ingressStatusEqual(updatedIng.Status.LoadBalancer.Ingress, ingress.Status.LoadBalancer.Ingress) {
+			conflictingIngressStatusUpdates.Inc()
+			return nil
+		}
+		return err
+
+	case err != nil:
+		return err
+
+	default:
+		return nil
+	}
+}
+
+func ingressStatusEqual(i1 []v1.LoadBalancerIngress, i2 []v1.LoadBalancerIngress) bool {
+	if len(i1) != len(i2) {
+		return false
+	}
+
+	for x := range i1 {
+		if i1[x] != i2[x] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -261,8 +261,11 @@ func (c *client) updateIngressAndHandleConflicts(ingressClient clientV1Beta1.Ing
 
 	switch {
 	case k8errors.IsConflict(err):
+		// In the event of a conflict, check whether another feed instance has already made the same ingress status
+		// change for us.
 		updatedIng, getErr := ingressClient.Get(ingress.Name, metav1.GetOptions{})
 		if getErr == nil && ingressStatusEqual(updatedIng.Status.LoadBalancer.Ingress, ingress.Status.LoadBalancer.Ingress) {
+			// Another feed instance has already made the appropriate change, no need to report an error.
 			return nil
 		}
 		return err

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -263,7 +263,6 @@ func (c *client) updateIngressAndHandleConflicts(ingressClient clientV1Beta1.Ing
 	case k8errors.IsConflict(err):
 		updatedIng, getErr := ingressClient.Get(ingress.Name, metav1.GetOptions{})
 		if getErr == nil && ingressStatusEqual(updatedIng.Status.LoadBalancer.Ingress, ingress.Status.LoadBalancer.Ingress) {
-			conflictingIngressStatusUpdates.Inc()
 			return nil
 		}
 		return err

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	clientV1Beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -42,7 +43,7 @@ var _ = Describe("Client", func() {
 			fakesStore = &cache.FakeCustomStore{}
 			fakesController = &fakeController{}
 			clt = &client{
-				clientset:           nil,
+				ingressGetter:       nil,
 				resyncPeriod:        resyncPeriod,
 				stopCh:              stopCh,
 				informerFactory:     fakesInformerFactory,
@@ -81,7 +82,7 @@ var _ = Describe("Client", func() {
 				existingController := &fakeController{}
 
 				clt = &client{
-					clientset:           nil,
+					ingressGetter:       nil,
 					resyncPeriod:        resyncPeriod,
 					stopCh:              stopCh,
 					informerFactory:     fakesInformerFactory,
@@ -151,7 +152,7 @@ var _ = Describe("Client", func() {
 				existingController := &fakeController{}
 
 				clt = &client{
-					clientset:           nil,
+					ingressGetter:       nil,
 					resyncPeriod:        resyncPeriod,
 					stopCh:              stopCh,
 					informerFactory:     fakesInformerFactory,
@@ -221,7 +222,7 @@ var _ = Describe("Client", func() {
 				existingController := &fakeController{}
 
 				clt = &client{
-					clientset:           nil,
+					ingressGetter:       nil,
 					resyncPeriod:        resyncPeriod,
 					stopCh:              stopCh,
 					informerFactory:     fakesInformerFactory,


### PR DESCRIPTION
The update of an ingress status by a given feed pod F1 is a get-modify-set operation, where another feed instance F2 may potentially complete the set operation while F1 is still at the modify stage.

What this means is that when F1 comes to do its set operation, it will get back from the API server a "409 Conflict" response, indicating that someone else has modified the resource after F1 fetched it.

This change makes the update routine a little more resilient. If a feed pod receives a conflict response back when it attempts to update the status, it will perform a second get operation, and compare the status on the returned object with the status it wanted to set. If these are equal, it will not return any error.

In the case where the status on the returned object is not equal to the value it wanted to set, it will surface the error exactly as it does right now. Likewise, if the error is anything other than a conflict, it
will be returned exactly as it is at the moment.