### PR TITLE
Validate the sky.uk/allow annotation entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.1.2
+* [BUGFIX] Validate `sky.uk/allow` annotation entries (#220)
+
 # v3.1.1
 * [BUGFIX] Wait for informer cache to be fully populated before interrogating it (#218)
 

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	"k8s.io/api/extensions/v1beta1"
@@ -64,6 +66,22 @@ func (e IngressEntry) validate() error {
 	if e.ServicePort == 0 {
 		return errors.New("missing service port")
 	}
+
+	var invalidAllowEntries []string
+	for _, allowEntry := range e.Allow {
+		if net.ParseIP(allowEntry) == nil {
+			if _, _, err := net.ParseCIDR(allowEntry); err != nil {
+				invalidAllowEntries = append(invalidAllowEntries, allowEntry)
+			}
+		}
+	}
+
+	if len(invalidAllowEntries) == 1 {
+		return fmt.Errorf("invalid entry in sky.uk/allow: %s", invalidAllowEntries[0])
+	} else if len(invalidAllowEntries) > 1 {
+		return fmt.Errorf("invalid entries in sky.uk/allow: %s", strings.Join(invalidAllowEntries, ","))
+	}
+
 	return nil
 }
 

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -71,15 +71,17 @@ func (e IngressEntry) validate() error {
 	for _, allowEntry := range e.Allow {
 		if net.ParseIP(allowEntry) == nil {
 			if _, _, err := net.ParseCIDR(allowEntry); err != nil {
-				invalidAllowEntries = append(invalidAllowEntries, allowEntry)
+				if allowEntry == "" {
+					invalidAllowEntries = append(invalidAllowEntries, "<empty>")
+				} else {
+					invalidAllowEntries = append(invalidAllowEntries, allowEntry)
+				}
 			}
 		}
 	}
 
-	if len(invalidAllowEntries) == 1 {
-		return fmt.Errorf("invalid entry in sky.uk/allow: %s", invalidAllowEntries[0])
-	} else if len(invalidAllowEntries) > 1 {
-		return fmt.Errorf("invalid entries in sky.uk/allow: %s", strings.Join(invalidAllowEntries, ","))
+	if len(invalidAllowEntries) > 0 {
+		return fmt.Errorf("host %s: invalid entries in sky.uk/allow: %s", e.Host, strings.Join(invalidAllowEntries, ","))
 	}
 
 	return nil

--- a/controller/ingress_entry_test.go
+++ b/controller/ingress_entry_test.go
@@ -1,0 +1,117 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleInvalidAllowAddressResultsInError(t *testing.T) {
+	// given
+	asserter := assert.New(t)
+
+	entry := IngressEntry{
+		Host:           "my-host",
+		ServiceAddress: "service",
+		ServicePort:    8080,
+		Allow:          []string{"invalid"},
+	}
+
+	// when
+	err := entry.validate()
+
+	// then
+	asserter.Error(err)
+	asserter.Equal(err.Error(), "invalid entry in sky.uk/allow: invalid")
+}
+
+func TestSingleInvalidAllowAddressAmongValidAddressesResultsInError(t *testing.T) {
+	// given
+	asserter := assert.New(t)
+
+	entry := IngressEntry{
+		Host:           "my-host",
+		ServiceAddress: "service",
+		ServicePort:    8080,
+		Allow:          []string{"1.2.3.4", "invalid", "192.168.0.1"},
+	}
+
+	// when
+	err := entry.validate()
+
+	// then
+	asserter.Error(err)
+	asserter.Equal(err.Error(), "invalid entry in sky.uk/allow: invalid")
+}
+
+func TestMultipleInvalidAllowAddressesResultInError(t *testing.T) {
+	// given
+	asserter := assert.New(t)
+
+	entry := IngressEntry{
+		Host:           "my-host",
+		ServiceAddress: "service",
+		ServicePort:    8080,
+		Allow:          []string{"invalid", "invalid-2"},
+	}
+
+	// when
+	err := entry.validate()
+
+	// then
+	asserter.Error(err)
+	asserter.Equal(err.Error(), "invalid entries in sky.uk/allow: invalid,invalid-2")
+}
+
+func TestValidAllowAddressResultsInNoError(t *testing.T) {
+	// given
+	asserter := assert.New(t)
+
+	entry := IngressEntry{
+		Host:           "my-host",
+		ServiceAddress: "service",
+		ServicePort:    8080,
+		Allow:          []string{"127.0.0.1"},
+	}
+
+	// when
+	err := entry.validate()
+
+	// then
+	asserter.NoError(err)
+}
+
+func TestValidAllowCIDRResultsInNoError(t *testing.T) {
+	// given
+	asserter := assert.New(t)
+
+	entry := IngressEntry{
+		Host:           "my-host",
+		ServiceAddress: "service",
+		ServicePort:    8080,
+		Allow:          []string{"192.0.2.0/24"},
+	}
+
+	// when
+	err := entry.validate()
+
+	// then
+	asserter.NoError(err)
+}
+
+func TestNoAllowAddressesResultInNoError(t *testing.T) {
+	// given
+	asserter := assert.New(t)
+
+	entry := IngressEntry{
+		Host:           "my-host",
+		ServiceAddress: "service",
+		ServicePort:    8080,
+	}
+
+	// when
+	err := entry.validate()
+
+	// then
+	asserter.NoError(err)
+}

--- a/controller/ingress_entry_test.go
+++ b/controller/ingress_entry_test.go
@@ -22,7 +22,7 @@ func TestSingleInvalidAllowAddressResultsInError(t *testing.T) {
 
 	// then
 	asserter.Error(err)
-	asserter.Equal(err.Error(), "invalid entry in sky.uk/allow: invalid")
+	asserter.Equal(err.Error(), "host my-host: invalid entries in sky.uk/allow: invalid")
 }
 
 func TestSingleInvalidAllowAddressAmongValidAddressesResultsInError(t *testing.T) {
@@ -41,7 +41,26 @@ func TestSingleInvalidAllowAddressAmongValidAddressesResultsInError(t *testing.T
 
 	// then
 	asserter.Error(err)
-	asserter.Equal(err.Error(), "invalid entry in sky.uk/allow: invalid")
+	asserter.Equal(err.Error(), "host my-host: invalid entries in sky.uk/allow: invalid")
+}
+
+func TestEmptyAllowAddressResultsInError(t *testing.T) {
+	// given
+	asserter := assert.New(t)
+
+	entry := IngressEntry{
+		Host:           "my-host",
+		ServiceAddress: "service",
+		ServicePort:    8080,
+		Allow:          []string{""},
+	}
+
+	// when
+	err := entry.validate()
+
+	// then
+	asserter.Error(err)
+	asserter.Equal(err.Error(), "host my-host: invalid entries in sky.uk/allow: <empty>")
 }
 
 func TestMultipleInvalidAllowAddressesResultInError(t *testing.T) {
@@ -60,7 +79,7 @@ func TestMultipleInvalidAllowAddressesResultInError(t *testing.T) {
 
 	// then
 	asserter.Error(err)
-	asserter.Equal(err.Error(), "invalid entries in sky.uk/allow: invalid,invalid-2")
+	asserter.Equal(err.Error(), "host my-host: invalid entries in sky.uk/allow: invalid,invalid-2")
 }
 
 func TestValidAllowAddressResultsInNoError(t *testing.T) {


### PR DESCRIPTION
Each comma-separated entry should be either an IP address or a CIDR range. Ingresses where this isn't the case will be skipped, with an error message logged detailing the invalid entries.