### PR TITLE
Trim whitespace from sky.uk/allow entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.1.3
+* [BUGFIX] Trim whitespace from sky.uk/allow entries (#223)
+
 # v3.1.2
 * [BUGFIX] Validate `sky.uk/allow` annotation entries (#220)
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -259,7 +259,11 @@ func (c *controller) updateIngresses() (err error) {
 							if allow == "" {
 								entry.Allow = []string{}
 							} else {
-								entry.Allow = strings.Split(allow, ",")
+								allowEntries := strings.Split(allow, ",")
+								for i := 0; i < len(allowEntries); i++ {
+									allowEntries[i] = strings.TrimSpace(allowEntries[i])
+								}
+								entry.Allow = allowEntries
 							}
 						}
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -506,6 +506,33 @@ func TestUpdaterIsUpdatedForIngressWithEmptyAllow(t *testing.T) {
 	})
 }
 
+func TestUpdaterIsUpdatedForIngressWithAllowContainingWhitespace(t *testing.T) {
+	runAndAssertUpdates(t, expectGetAllIngresses, testSpec{
+		"ingress with empty allow",
+		createIngressesFixture(ingressNamespace, ingressHost, ingressSvcName, ingressSvcPort, map[string]string{
+			ingressAllowAnnotation:   "127.0.0.1, 192.168.0.1,\n10.1.2.3",
+			backendTimeoutSeconds:    "10",
+			frontendSchemeAnnotation: "internal",
+			ingressClassAnnotation:   defaultIngressClass,
+		}, ingressPath),
+		createDefaultServices(),
+		createDefaultNamespaces(),
+		[]IngressEntry{{
+			Namespace:             ingressNamespace,
+			Name:                  ingressName,
+			Host:                  ingressHost,
+			Path:                  ingressPath,
+			ServiceAddress:        serviceIP,
+			ServicePort:           ingressSvcPort,
+			LbScheme:              "internal",
+			IngressClass:          defaultIngressClass,
+			Allow:                 []string{"127.0.0.1", "192.168.0.1", "10.1.2.3"},
+			BackendTimeoutSeconds: backendTimeout,
+		}},
+		defaultConfig(),
+	})
+}
+
 func TestUpdaterIsUpdatedForIngressWithStripPathsTrue(t *testing.T) {
 	runAndAssertUpdates(t, expectGetAllIngresses, testSpec{
 		"ingress with strip paths set to true",


### PR DESCRIPTION
Ensures that additional whitespace around ingress entries does not stop them being recognised as valid addresses or ranges.