### PR TITLE
Generate the root path location for servers without the root ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.1.5
+* [BUGFIX] Generate the root path location for servers without the root ingress (#225)
+
 # v3.1.4
 * [BUGFIX] Account for concurrent status updates (#219)
 

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -443,6 +443,15 @@ func upstreamID(e controller.IngressEntry) string {
 	return fmt.Sprintf("%s.%s.%d", e.Namespace, e.ServiceAddress, e.ServicePort)
 }
 
+func (s server) HasRootLocation() bool {
+	for i := range s.Locations {
+		if s.Locations[i].Path == "/" {
+			return true
+		}
+	}
+	return false
+}
+
 type servers []*server
 
 func (s servers) Len() int           { return len(s) }

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -190,6 +190,11 @@ http {
             deny all;
         }
         {{- end }}
+        {{- if not $entry.HasRootLocation }}
+        location / {
+            return 404;
+        }
+        {{- end }}
     }
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Nginx included in the feed docker image doesn' t produce "404 Not Found" for servers which ingresses don't contain an ingress for the root path. Instead, the default Nginx index page is used as the response. 

To stop this behaviour, for all servers without the root ingress, the additional location for the root path will be added to locations generated from ingresses. This location will return "404 Not Found".

Required by sky-uk/core-infrastructure#6782 (https://github.com/sky-uk/core-infrastructure/issues/6782#issuecomment-619034128)
