### PR TITLE
Reduce number of DescribeTargetGroups calls on NLB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.1.6
+* [BUGFIX] Reduce the number of DescribeTargetGroups to avoid reaching the API limits
+* [BUGFIX] Do not set the nlb updater as initialised if it failed to describe the target groups
+
 # v3.1.5
 * [BUGFIX] Generate the root path location for servers without the root ingress (#225)
 


### PR DESCRIPTION
This changes from one call per load balancer to one call to get the
information for available target groups. This is needed so that the
number of API calls is reduced to avoid becoming rate limited.

It now also returns an error if the target group information can't be
retrieved, instead of ignoring the failure, and setting TargetGroups to
nil. This caused feed to mark itself as initialised, when it wasn't, and
it never recovered. Now that it fails, it should retry to register in
the next Update cycle.