### PR TITLE
Support latest backend config for nginx upstream module

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/feed/k8s"
@@ -31,9 +32,11 @@ const (
 	stripPathAnnotation = "sky.uk/strip-path"
 	exactPathAnnotation = "sky.uk/exact-path"
 
-	backendTimeoutSeconds       = "sky.uk/backend-timeout-seconds"
-	proxyBufferSizeAnnotation   = "sky.uk/proxy-buffer-size-in-kb"
-	proxyBufferBlocksAnnotation = "sky.uk/proxy-buffer-blocks"
+	backendTimeoutSeconds           = "sky.uk/backend-timeout-seconds"
+	backendConnectionKeepalive      = "sky.uk/backend-connection-keepalive"
+	backendMaxRequestsPerConnection = "sky.uk/backend-max-requests-per-connection"
+	proxyBufferSizeAnnotation       = "sky.uk/proxy-buffer-size-in-kb"
+	proxyBufferBlocksAnnotation     = "sky.uk/proxy-buffer-blocks"
 
 	maxAllowedProxyBufferSize   = 32
 	maxAllowedProxyBufferBlocks = 8
@@ -302,6 +305,16 @@ func (c *controller) updateIngresses() (err error) {
 						if maxConnections, ok := ingress.Annotations[backendMaxConnections]; ok {
 							tmp, _ := strconv.Atoi(maxConnections)
 							entry.BackendMaxConnections = tmp
+						}
+
+						if maxRequestsPerConnection, ok := ingress.Annotations[backendMaxRequestsPerConnection]; ok {
+							intVal, _ := strconv.Atoi(maxRequestsPerConnection)
+							entry.BackendMaxRequestsPerConnection = intVal
+						}
+
+						if connectionKeepalive, ok := ingress.Annotations[backendConnectionKeepalive]; ok {
+							keepaliveTimeout, _ := time.ParseDuration(connectionKeepalive)
+							entry.BackendKeepaliveTimeout = keepaliveTimeout
 						}
 
 						if proxyBufferSizeString, ok := ingress.Annotations[proxyBufferSizeAnnotation]; ok {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -828,6 +828,37 @@ func TestUpdaterIsUpdatedForIngressWithOverriddenBackendConnectionKeepAlive(t *t
 	})
 }
 
+func TestUpdaterSkipsEntriesForIngressWithInvalidBackendConnectionKeepAliveAndBackendMaxRequestsPerConnection(t *testing.T) {
+	runAndAssertUpdates(t, expectGetAllIngresses, testSpec{
+		"ingress with overridden backend max requests per connection",
+		createIngressesFixture(ingressNamespace, ingressHost, ingressSvcName, ingressSvcPort, map[string]string{
+			ingressAllowAnnotation:          "",
+			stripPathAnnotation:             "false",
+			frontendSchemeAnnotation:        "internal",
+			ingressClassAnnotation:          defaultIngressClass,
+			backendConnectionKeepalive:      "50a",
+			backendMaxRequestsPerConnection: "-1",
+		}, ingressPath),
+		createDefaultServices(),
+		createDefaultNamespaces(),
+		[]IngressEntry{{
+			Namespace:             ingressNamespace,
+			Name:                  ingressName,
+			Host:                  ingressHost,
+			Path:                  ingressPath,
+			ServiceAddress:        serviceIP,
+			ServicePort:           ingressSvcPort,
+			LbScheme:              "internal",
+			IngressClass:          defaultIngressClass,
+			Allow:                 []string{},
+			StripPaths:            false,
+			BackendTimeoutSeconds: 10,
+			BackendMaxConnections: defaultMaxConnections,
+		}},
+		defaultConfig(),
+	})
+}
+
 func TestUpdaterIsUpdatedForIngressWithDefaultBackendMaxConnections(t *testing.T) {
 	runAndAssertUpdates(t, expectGetAllIngresses, testSpec{
 		"ingress with default backend max connections",

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -766,6 +766,68 @@ func TestUpdaterIsUpdatedForIngressWithOverriddenBackendMaxConnections(t *testin
 	})
 }
 
+func TestUpdaterIsUpdatedForIngressWithOverriddenBackendMaxRequestsPerConnection(t *testing.T) {
+	runAndAssertUpdates(t, expectGetAllIngresses, testSpec{
+		"ingress with overridden backend max requests per connection",
+		createIngressesFixture(ingressNamespace, ingressHost, ingressSvcName, ingressSvcPort, map[string]string{
+			ingressAllowAnnotation:          "",
+			stripPathAnnotation:             "false",
+			frontendSchemeAnnotation:        "internal",
+			ingressClassAnnotation:          defaultIngressClass,
+			backendMaxRequestsPerConnection: "100",
+		}, ingressPath),
+		createDefaultServices(),
+		createDefaultNamespaces(),
+		[]IngressEntry{{
+			Namespace:                       ingressNamespace,
+			Name:                            ingressName,
+			Host:                            ingressHost,
+			Path:                            ingressPath,
+			ServiceAddress:                  serviceIP,
+			ServicePort:                     ingressSvcPort,
+			LbScheme:                        "internal",
+			IngressClass:                    defaultIngressClass,
+			Allow:                           []string{},
+			StripPaths:                      false,
+			BackendTimeoutSeconds:           10,
+			BackendMaxConnections:           defaultMaxConnections,
+			BackendMaxRequestsPerConnection: 100,
+		}},
+		defaultConfig(),
+	})
+}
+
+func TestUpdaterIsUpdatedForIngressWithOverriddenBackendConnectionKeepAlive(t *testing.T) {
+	runAndAssertUpdates(t, expectGetAllIngresses, testSpec{
+		"ingress with overridden backend max requests per connection",
+		createIngressesFixture(ingressNamespace, ingressHost, ingressSvcName, ingressSvcPort, map[string]string{
+			ingressAllowAnnotation:     "",
+			stripPathAnnotation:        "false",
+			frontendSchemeAnnotation:   "internal",
+			ingressClassAnnotation:     defaultIngressClass,
+			backendConnectionKeepalive: "5m",
+		}, ingressPath),
+		createDefaultServices(),
+		createDefaultNamespaces(),
+		[]IngressEntry{{
+			Namespace:               ingressNamespace,
+			Name:                    ingressName,
+			Host:                    ingressHost,
+			Path:                    ingressPath,
+			ServiceAddress:          serviceIP,
+			ServicePort:             ingressSvcPort,
+			LbScheme:                "internal",
+			IngressClass:            defaultIngressClass,
+			Allow:                   []string{},
+			StripPaths:              false,
+			BackendTimeoutSeconds:   10,
+			BackendMaxConnections:   defaultMaxConnections,
+			BackendKeepaliveTimeout: 5 * time.Minute,
+		}},
+		defaultConfig(),
+	})
+}
+
 func TestUpdaterIsUpdatedForIngressWithDefaultBackendMaxConnections(t *testing.T) {
 	runAndAssertUpdates(t, expectGetAllIngresses, testSpec{
 		"ingress with default backend max connections",
@@ -1329,6 +1391,10 @@ func createIngressesFixture(namespace string, host string, serviceName string, s
 			annotations[proxyBufferBlocksAnnotation] = annotationVal
 		case ingressClassAnnotation:
 			annotations[ingressClassAnnotation] = annotationVal
+		case backendConnectionKeepalive:
+			annotations[backendConnectionKeepalive] = annotationVal
+		case backendMaxRequestsPerConnection:
+			annotations[backendMaxRequestsPerConnection] = annotationVal
 		}
 	}
 

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -42,6 +42,10 @@ type IngressEntry struct {
 	BackendTimeoutSeconds int
 	// BackendMaxConnections maximum backend connections
 	BackendMaxConnections int
+	// BackendKeepaliveTimeout timeout for idle connections to upstream
+	BackendKeepaliveTimeout time.Duration
+	// BackendMaxRequestsPerConnection max requests per connection to upstream, after which it will be closed
+	BackendMaxRequestsPerConnection int
 	// Ingress creation time
 	CreationTimestamp time.Time
 	// Ingress resource

--- a/controller/ingress_entry.go
+++ b/controller/ingress_entry.go
@@ -45,7 +45,7 @@ type IngressEntry struct {
 	// BackendKeepaliveTimeout timeout for idle connections to upstream
 	BackendKeepaliveTimeout time.Duration
 	// BackendMaxRequestsPerConnection max requests per connection to upstream, after which it will be closed
-	BackendMaxRequestsPerConnection int
+	BackendMaxRequestsPerConnection uint64
 	// Ingress creation time
 	CreationTimestamp time.Time
 	// Ingress resource

--- a/go.mod
+++ b/go.mod
@@ -64,8 +64,9 @@ require (
 	golang.org/x/image v0.0.0-20190828090100-23ea20f87cfc // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/mobile v0.0.0-20190826170111-cafc553e1ac5 // indirect
+	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/sys v0.0.0-20191104094858-e8c54fb511f6 // indirect
-	golang.org/x/tools v0.0.0-20200312194400-c312e98713c2 // indirect
+	golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff // indirect
 	google.golang.org/api v0.9.0 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
 	google.golang.org/grpc v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	golang.org/x/mobile v0.0.0-20190826170111-cafc553e1ac5 // indirect
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/sys v0.0.0-20191104094858-e8c54fb511f6 // indirect
-	golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff // indirect
+	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
 	google.golang.org/api v0.9.0 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
 	google.golang.org/grpc v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,7 @@ github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f h1:nBX3nTcmxEtHS
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -330,6 +331,8 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -429,6 +432,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200312194400-c312e98713c2 h1:6TB4+MaZlkcSsJDu+BS5yxSEuZIYhjWz+jhbSLEZylI=
 golang.org/x/tools v0.0.0-20200312194400-c312e98713c2/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff h1:foic6oVZ4MKltJC6MXzuFZFswE7NCjjtc0Hxbyblawc=
+golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/go.sum
+++ b/go.sum
@@ -434,6 +434,10 @@ golang.org/x/tools v0.0.0-20200312194400-c312e98713c2 h1:6TB4+MaZlkcSsJDu+BS5yxS
 golang.org/x/tools v0.0.0-20200312194400-c312e98713c2/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff h1:foic6oVZ4MKltJC6MXzuFZFswE7NCjjtc0Hxbyblawc=
 golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200626032829-bcbc01e07a20 h1:q+ysxVHVQNTVHgzwjuk4ApAILRbfOLARfnEaqCIBR6A=
+golang.org/x/tools v0.0.0-20200626032829-bcbc01e07a20/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f h1:JcoF/bowzCDI+MXu1yLqQGNO3ibqWsWq+Sk7pOT218w=
+golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -453,7 +453,7 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 }
 
 func upstreamID(e controller.IngressEntry) string {
-	return fmt.Sprintf("%s.%s.%d", e.Namespace, e.ServiceAddress, e.ServicePort)
+	return fmt.Sprintf("%s.%s.%s.%d", e.Namespace, e.Name, e.ServiceAddress, e.ServicePort)
 }
 
 func (s server) HasRootLocation() bool {

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -22,7 +22,7 @@ import (
 const (
 	nginxStartDelay                         = time.Millisecond * 100
 	metricsUpdateInterval                   = time.Second * 10
-	defaultMaxRequestsPerUpstreamConnection = 1024
+	defaultMaxRequestsPerUpstreamConnection = uint64(1024)
 )
 
 // Port configuration
@@ -135,7 +135,7 @@ type upstream struct {
 	Server            string
 	MaxConnections    int
 	KeepaliveTimeout  string
-	KeepaliveRequests int
+	KeepaliveRequests uint64
 }
 
 type location struct {
@@ -431,7 +431,7 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 		}
 		keepaliveTimeout := ""
 		if ingressEntry.BackendKeepaliveTimeout != 0 {
-			keepaliveTimeout = fmt.Sprintf("%ds", int64(ingressEntry.BackendKeepaliveTimeout.Seconds()))
+			keepaliveTimeout = fmt.Sprintf("%ds", uint64(ingressEntry.BackendKeepaliveTimeout.Seconds()))
 		}
 		upstream := &upstream{
 			ID:                upstreamID(ingressEntry),

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	nginxStartDelay       = time.Millisecond * 100
-	metricsUpdateInterval = time.Second * 10
+	nginxStartDelay                         = time.Millisecond * 100
+	metricsUpdateInterval                   = time.Second * 10
+	defaultMaxRequestsPerUpstreamConnection = 1024
 )
 
 // Port configuration
@@ -130,9 +131,11 @@ type server struct {
 }
 
 type upstream struct {
-	ID             string
-	Server         string
-	MaxConnections int
+	ID                string
+	Server            string
+	MaxConnections    int
+	KeepaliveTimeout  string
+	KeepaliveRequests int
 }
 
 type location struct {
@@ -422,10 +425,20 @@ func createUpstreamEntries(entries controller.IngressEntries) []*upstream {
 	idToUpstream := make(map[string]*upstream)
 
 	for _, ingressEntry := range entries {
+		maxRequestsPerConnection := defaultMaxRequestsPerUpstreamConnection
+		if ingressEntry.BackendMaxRequestsPerConnection != 0 {
+			maxRequestsPerConnection = ingressEntry.BackendMaxRequestsPerConnection
+		}
+		keepaliveTimeout := ""
+		if ingressEntry.BackendKeepaliveTimeout != 0 {
+			keepaliveTimeout = fmt.Sprintf("%ds", int64(ingressEntry.BackendKeepaliveTimeout.Seconds()))
+		}
 		upstream := &upstream{
-			ID:             upstreamID(ingressEntry),
-			Server:         fmt.Sprintf("%s:%d", ingressEntry.ServiceAddress, ingressEntry.ServicePort),
-			MaxConnections: ingressEntry.BackendMaxConnections,
+			ID:                upstreamID(ingressEntry),
+			Server:            fmt.Sprintf("%s:%d", ingressEntry.ServiceAddress, ingressEntry.ServicePort),
+			MaxConnections:    ingressEntry.BackendMaxConnections,
+			KeepaliveRequests: maxRequestsPerConnection,
+			KeepaliveTimeout:  keepaliveTimeout,
 		}
 		idToUpstream[upstream.ID] = upstream
 	}

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -130,6 +130,10 @@ http {
     upstream {{ $upstream.ID }} {
         server {{ $upstream.Server }} max_conns={{ $upstream.MaxConnections }};
         keepalive {{ $keepalive }};
+        keepalive_requests {{ $upstream.KeepaliveRequests }};
+        {{- if ne $upstream.KeepaliveTimeout "" }}
+        keepalive_timeout {{ $upstream.KeepaliveTimeout}};
+        {{- end }}
     }
 {{ end }}
 

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -555,10 +555,25 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
+					Host:                            "foo.com",
+					Namespace:                       "core",
+					Name:                            "foo-ingress",
+					Path:                            "/path",
+					ServiceAddress:                  "service",
+					ServicePort:                     8080,
+					Allow:                           []string{"10.82.0.0/16"},
+					StripPaths:                      true,
+					ExactPath:                       false,
+					BackendTimeoutSeconds:           1,
+					BackendKeepaliveTimeout:         2 * time.Minute,
+					BackendMaxConnections:           300,
+					BackendMaxRequestsPerConnection: 2000,
+				},
+				{
 					Host:                  "foo.com",
 					Namespace:             "core",
-					Name:                  "foo-ingress",
-					Path:                  "/path",
+					Name:                  "foo-ingress-different-path",
+					Path:                  "/same-service-different-path",
 					ServiceAddress:        "service",
 					ServicePort:           8080,
 					Allow:                 []string{"10.82.0.0/16"},
@@ -583,16 +598,22 @@ func TestNginxIngressEntries(t *testing.T) {
 				},
 			},
 			[]string{
-				"    upstream core.anotherservice.6060 {\n" +
+				"    upstream core.foo-ingress-another.anotherservice.6060 {\n" +
 					"        server anotherservice:6060 max_conns=1024;\n" +
 					"        keepalive 1024;\n" +
 					"        keepalive_requests 100;\n" +
 					"        keepalive_timeout 300s;\n" +
 					"    }",
-				"    upstream core.service.8080 {\n" +
+				"    upstream core.foo-ingress-different-path.service.8080 {\n" +
 					"        server service:8080 max_conns=0;\n" +
 					"        keepalive 1024;\n" +
 					"        keepalive_requests 1024;\n" +
+					"    }",
+				"    upstream core.foo-ingress.service.8080 {\n" +
+					"        server service:8080 max_conns=300;\n" +
+					"        keepalive 1024;\n" +
+					"        keepalive_requests 2000;\n" +
+					"        keepalive_timeout 120s;\n" +
 					"    }",
 			},
 			[]string{
@@ -605,7 +626,7 @@ func TestNginxIngressEntries(t *testing.T) {
 					"\n" +
 					"        location /anotherpath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.anotherservice.6060;\n" +
+					"            proxy_pass http://core.foo-ingress-another.anotherservice.6060;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /anotherpath/::$proxy_host $server_name;\n" +
@@ -628,10 +649,33 @@ func TestNginxIngressEntries(t *testing.T) {
 					"        location /path/ {\n" +
 					"            # Strip location path when proxying.\n" +
 					"            # Beware this can cause issues with url encoded characters.\n" +
-					"            proxy_pass http://core.service.8080/;\n" +
+					"            proxy_pass http://core.foo-ingress.service.8080/;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /path/::$proxy_host $server_name;\n" +
+					"\n" +
+					"            # Close proxy connections after backend keepalive time.\n" +
+					"            proxy_read_timeout 1s;\n" +
+					"            proxy_send_timeout 1s;\n" +
+					"            proxy_buffer_size 0k;\n" +
+					"            proxy_buffers 0 0k;\n" +
+					"\n" +
+					"            # Allow localhost for debugging\n" +
+					"            allow 127.0.0.1;\n" +
+					"\n" +
+					"            # Restrict clients\n" +
+					"            allow 10.82.0.0/16;\n" +
+					"            \n" +
+					"            deny all;\n" +
+					"        }\n" +
+					"\n" +
+					"        location /same-service-different-path/ {\n" +
+					"            # Strip location path when proxying.\n" +
+					"            # Beware this can cause issues with url encoded characters.\n" +
+					"            proxy_pass http://core.foo-ingress-different-path.service.8080/;\n" +
+					"\n" +
+					"            # Set display name for vhost stats.\n" +
+					"            vhost_traffic_status_filter_by_set_key /same-service-different-path/::$proxy_host $server_name;\n" +
 					"\n" +
 					"            # Close proxy connections after backend keepalive time.\n" +
 					"            proxy_read_timeout 1s;\n" +
@@ -808,7 +852,7 @@ func TestNginxIngressEntries(t *testing.T) {
 				"\n" +
 				"        location / {\n" +
 				"            # Keep original path when proxying.\n" +
-				"            proxy_pass http://core.foo.8080;\n" +
+				"            proxy_pass http://core.0-first-ingress.foo.8080;\n" +
 				"\n" +
 				"            # Set display name for vhost stats.\n" +
 				"            vhost_traffic_status_filter_by_set_key /::$proxy_host $server_name;\n" +
@@ -856,7 +900,7 @@ func TestNginxIngressEntries(t *testing.T) {
 				},
 			},
 			nil,
-			[]string{"proxy_pass http://core.service-1.8080"},
+			[]string{"proxy_pass http://core.ingress.service-1.8080"},
 		},
 		{
 			"Duplicate host/path entries are ignored, the first one is kept order by Port",
@@ -884,7 +928,7 @@ func TestNginxIngressEntries(t *testing.T) {
 				},
 			},
 			nil,
-			[]string{"proxy_pass http://core.service.1"},
+			[]string{"proxy_pass http://core.ingress.service.1"},
 		},
 		{
 			"Check path slashes are added correctly",
@@ -1006,7 +1050,7 @@ func TestNginxIngressEntries(t *testing.T) {
 			},
 
 			[]string{
-				"    upstream core.service.9090 {\n" +
+				"    upstream core.foo-ingress.service.9090 {\n" +
 					"        server service:9090 max_conns=0;\n" +
 					"        keepalive 1024;\n" +
 					"        keepalive_requests 1024;\n" +
@@ -1056,7 +1100,7 @@ func TestNginxIngressEntries(t *testing.T) {
 			},
 			nil,
 			[]string{
-				"    proxy_pass http://core.service.9090;\n",
+				"    proxy_pass http://core.foo-ingress.service.9090;\n",
 			},
 		},
 		{
@@ -1113,7 +1157,7 @@ func TestNginxIngressEntries(t *testing.T) {
 			[]string{
 				"        location / {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.9090;\n" +
+					"            proxy_pass http://core.foo-ingress.service.9090;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /::$proxy_host $server_name;\n" +
@@ -1134,7 +1178,7 @@ func TestNginxIngressEntries(t *testing.T) {
 					"\n" +
 					"        location /01234-hi/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.9090;\n" +
+					"            proxy_pass http://core.foo-ingress.service.9090;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /01234-hi/::$proxy_host $server_name;\n" +
@@ -1155,7 +1199,7 @@ func TestNginxIngressEntries(t *testing.T) {
 					"\n" +
 					"        location /lala/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.9090;\n" +
+					"            proxy_pass http://core.foo-ingress.service.9090;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /lala/::$proxy_host $server_name;\n" +
@@ -1212,7 +1256,7 @@ func TestNginxIngressEntries(t *testing.T) {
 			[]string{
 				"        location /some-path/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.9090;\n" +
+					"            proxy_pass http://core.some-ingress.service.9090;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /some-path/::$proxy_host $server_name;\n" +
@@ -1304,7 +1348,7 @@ func TestNginxRootPathLocations(t *testing.T) {
 					"\n" +
 					"        location /anotherpath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.anotherservice.6060;\n" +
+					"            proxy_pass http://core.no-root-location-ingress-another.anotherservice.6060;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /anotherpath/::$proxy_host $server_name;\n" +
@@ -1325,7 +1369,7 @@ func TestNginxRootPathLocations(t *testing.T) {
 					"\n" +
 					"        location /path/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.8080;\n" +
+					"            proxy_pass http://core.no-root-location-ingress.service.8080;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /path/::$proxy_host $server_name;\n" +
@@ -1378,7 +1422,7 @@ func TestNginxRootPathLocations(t *testing.T) {
 					"\n" +
 					"        location / {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.7123;\n" +
+					"            proxy_pass http://core.root-location-ingress.service.7123;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /::$proxy_host $server_name;\n" +
@@ -1399,7 +1443,7 @@ func TestNginxRootPathLocations(t *testing.T) {
 					"\n" +
 					"        location /somepath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.someservice.7124;\n" +
+					"            proxy_pass http://core.some-root-location-ingress.someservice.7124;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /somepath/::$proxy_host $server_name;\n" +
@@ -1450,7 +1494,7 @@ func TestNginxRootPathLocations(t *testing.T) {
 					"\n" +
 					"        location = / {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.7123;\n" +
+					"            proxy_pass http://core.root-location-ingress.service.7123;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /::$proxy_host $server_name;\n" +
@@ -1471,7 +1515,7 @@ func TestNginxRootPathLocations(t *testing.T) {
 					"\n" +
 					"        location /somepath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.someservice.7124;\n" +
+					"            proxy_pass http://core.some-root-location-ingress.someservice.7124;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /somepath/::$proxy_host $server_name;\n" +
@@ -1592,7 +1636,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /anotherpath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.anotherservice.6060;\n" +
+					"            proxy_pass http://core.another-ingress.anotherservice.6060;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /anotherpath/::$proxy_host $server_name;\n" +
@@ -1613,7 +1657,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /path/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.8080;\n" +
+					"            proxy_pass http://core.an-ingress.service.8080;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /path/::$proxy_host $server_name;\n" +
@@ -1646,7 +1690,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location / {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.8080;\n" +
+					"            proxy_pass http://core.an-ingress.service.8080;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /::$proxy_host $server_name;\n" +
@@ -1667,7 +1711,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /anotherpath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.anotherservice.6060;\n" +
+					"            proxy_pass http://core.another-ingress.anotherservice.6060;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /anotherpath/::$proxy_host $server_name;\n" +
@@ -1688,7 +1732,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /path/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.8080;\n" +
+					"            proxy_pass http://core.an-ingress.service.8080;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /path/::$proxy_host $server_name;\n" +
@@ -1766,7 +1810,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location / {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.8080;\n" +
+					"            proxy_pass http://core.an-ingress.service.8080;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /::$proxy_host $server_name;\n" +
@@ -1787,7 +1831,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /anotherpath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.anotherservice.6060;\n" +
+					"            proxy_pass http://core.another-ingress.anotherservice.6060;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /anotherpath/::$proxy_host $server_name;\n" +
@@ -1808,7 +1852,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /path/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.8080;\n" +
+					"            proxy_pass http://core.an-ingress.service.8080;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /path/::$proxy_host $server_name;\n" +
@@ -1838,7 +1882,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /anotherpath/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.anotherservice.6060;\n" +
+					"            proxy_pass http://core.another-ingress.anotherservice.6060;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /anotherpath/::$proxy_host $server_name;\n" +
@@ -1859,7 +1903,7 @@ func TestNginxRootPathLocationsUpdates(t *testing.T) {
 					"\n" +
 					"        location /path/ {\n" +
 					"            # Keep original path when proxying.\n" +
-					"            proxy_pass http://core.service.8080;\n" +
+					"            proxy_pass http://core.an-ingress.service.8080;\n" +
 					"\n" +
 					"            # Set display name for vhost stats.\n" +
 					"            vhost_traffic_status_filter_by_set_key /path/::$proxy_host $server_name;\n" +

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -555,9 +555,9 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:                  "chris.com",
+					Host:                  "foo.com",
 					Namespace:             "core",
-					Name:                  "chris-ingress",
+					Name:                  "foo-ingress",
 					Path:                  "/path",
 					ServiceAddress:        "service",
 					ServicePort:           8080,
@@ -567,33 +567,38 @@ func TestNginxIngressEntries(t *testing.T) {
 					BackendTimeoutSeconds: 1,
 				},
 				{
-					Host:                  "chris.com",
-					Namespace:             "core",
-					Name:                  "chris-ingress-another",
-					Path:                  "/anotherpath",
-					ServiceAddress:        "anotherservice",
-					ServicePort:           6060,
-					Allow:                 []string{"10.86.0.0/16"},
-					StripPaths:            false,
-					ExactPath:             false,
-					BackendTimeoutSeconds: 10,
-					BackendMaxConnections: 1024,
+					Host:                            "foo.com",
+					Namespace:                       "core",
+					Name:                            "foo-ingress-another",
+					Path:                            "/anotherpath",
+					ServiceAddress:                  "anotherservice",
+					ServicePort:                     6060,
+					Allow:                           []string{"10.86.0.0/16"},
+					StripPaths:                      false,
+					ExactPath:                       false,
+					BackendTimeoutSeconds:           10,
+					BackendMaxRequestsPerConnection: 100,
+					BackendKeepaliveTimeout:         5 * time.Minute,
+					BackendMaxConnections:           1024,
 				},
 			},
 			[]string{
 				"    upstream core.anotherservice.6060 {\n" +
 					"        server anotherservice:6060 max_conns=1024;\n" +
 					"        keepalive 1024;\n" +
+					"        keepalive_requests 100;\n" +
+					"        keepalive_timeout 300s;\n" +
 					"    }",
 				"    upstream core.service.8080 {\n" +
 					"        server service:8080 max_conns=0;\n" +
 					"        keepalive 1024;\n" +
+					"        keepalive_requests 1024;\n" +
 					"    }",
 			},
 			[]string{
 				"    server {\n" +
 					"        listen 9090;\n" +
-					"        server_name chris.com;\n" +
+					"        server_name foo.com;\n" +
 					"\n" +
 					"        # disable any limits to avoid HTTP 413 for large uploads\n" +
 					"        client_max_body_size 0;\n" +
@@ -653,9 +658,9 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/path",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -674,9 +679,9 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/path",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -886,41 +891,41 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris-0.com",
+					Host:           "foo-0.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "",
 					ServiceAddress: "service",
 					ServicePort:    9090,
 				},
 				{
-					Host:           "chris-1.com",
+					Host:           "foo-1.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/prefix-with-slash/",
 					ServiceAddress: "service",
 					ServicePort:    9090,
 				},
 				{
-					Host:           "chris-2.com",
+					Host:           "foo-2.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "prefix-without-preslash/",
 					ServiceAddress: "service",
 					ServicePort:    9090,
 				},
 				{
-					Host:           "chris-3.com",
+					Host:           "foo-3.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/prefix-without-postslash",
 					ServiceAddress: "service",
 					ServicePort:    9090,
 				},
 				{
-					Host:           "chris-4.com",
+					Host:           "foo-4.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "prefix-without-anyslash",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -940,9 +945,9 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris-0.com",
+					Host:           "foo-0.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/a/test/path",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -959,9 +964,9 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -982,18 +987,18 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/my-path",
 					ServiceAddress: "service",
 					ServicePort:    9090,
 				},
 
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/my-path2",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -1004,6 +1009,7 @@ func TestNginxIngressEntries(t *testing.T) {
 				"    upstream core.service.9090 {\n" +
 					"        server service:9090 max_conns=0;\n" +
 					"        keepalive 1024;\n" +
+					"        keepalive_requests 1024;\n" +
 					"    }",
 			},
 			nil,
@@ -1013,18 +1019,18 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "02chris-ingress",
+					Name:           "02foo-ingress",
 					Path:           "/my-path",
 					ServiceAddress: "service",
 					ServicePort:    9090,
 				},
 
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "01chris-ingress",
+					Name:           "01foo-ingress",
 					Path:           "/my-path2",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -1032,7 +1038,7 @@ func TestNginxIngressEntries(t *testing.T) {
 			},
 			nil,
 			[]string{
-				"# ingress: core/01chris-ingress core/02chris-ingress",
+				"# ingress: core/01foo-ingress core/02foo-ingress",
 			},
 		},
 		{
@@ -1040,9 +1046,9 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/path",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -1058,9 +1064,9 @@ func TestNginxIngressEntries(t *testing.T) {
 			enableProxyProtocolConf,
 			[]controller.IngressEntry{
 				{
-					Host:           "chris.com",
+					Host:           "foo.com",
 					Namespace:      "core",
-					Name:           "chris-ingress",
+					Name:           "foo-ingress",
 					Path:           "/path",
 					ServiceAddress: "service",
 					ServicePort:    9090,
@@ -1076,27 +1082,27 @@ func TestNginxIngressEntries(t *testing.T) {
 			defaultConf,
 			[]controller.IngressEntry{
 				{
-					Host:                  "chris.com",
+					Host:                  "foo.com",
 					Namespace:             "core",
-					Name:                  "chris-ingress",
+					Name:                  "foo-ingress",
 					Path:                  "",
 					ServiceAddress:        "service",
 					ServicePort:           9090,
 					BackendTimeoutSeconds: 28,
 				},
 				{
-					Host:                  "chris.com",
+					Host:                  "foo.com",
 					Namespace:             "core",
-					Name:                  "chris-ingress",
+					Name:                  "foo-ingress",
 					Path:                  "/lala",
 					ServiceAddress:        "service",
 					ServicePort:           9090,
 					BackendTimeoutSeconds: 28,
 				},
 				{
-					Host:                  "chris.com",
+					Host:                  "foo.com",
 					Namespace:             "core",
-					Name:                  "chris-ingress",
+					Name:                  "foo-ingress",
 					Path:                  "/01234-hi",
 					ServiceAddress:        "service",
 					ServicePort:           9090,
@@ -1952,7 +1958,7 @@ func TestDoesNotUpdateIfConfigurationHasNotChanged(t *testing.T) {
 
 	entries := []controller.IngressEntry{
 		{
-			Host:           "chris.com",
+			Host:           "foo.com",
 			Path:           "/path",
 			ServiceAddress: "service",
 			ServicePort:    9090,
@@ -1984,7 +1990,7 @@ func TestRateLimitedForUpdates(t *testing.T) {
 
 	entries := []controller.IngressEntry{
 		{
-			Host:           "chris.com",
+			Host:           "foo.com",
 			Path:           "/path",
 			ServiceAddress: "service",
 			ServicePort:    9090,
@@ -1993,7 +1999,7 @@ func TestRateLimitedForUpdates(t *testing.T) {
 
 	updatedEntries := []controller.IngressEntry{
 		{
-			Host:           "chris.com",
+			Host:           "foo.com",
 			Path:           "/path",
 			ServiceAddress: "somethingdifferent",
 			ServicePort:    9090,
@@ -2161,7 +2167,7 @@ func TestFailsToUpdateIfConfigurationIsBroken(t *testing.T) {
 
 	entries := []controller.IngressEntry{
 		{
-			Host:           "chris.com",
+			Host:           "foo.com",
 			Path:           "/path",
 			ServiceAddress: "service",
 			ServicePort:    9090,


### PR DESCRIPTION
- Support setting `keepalive_requests` and `keepalive_timeout` for nginx upstream module
- Support annotations on ingress to be able to set the values in nginx config for each upstream