### PR TITLE
Add support for multiple namespace selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v4.3.0
+* Provide support for multiple labels for namespace selection
+  * Remove flag `--ingress-controller-namespace-selector`
+  * Add flag `--ingress-controller-namespace-selectors` - which can accept comma separated or repeated inputs
+  * Add flag `--match-all-namespace-selectors` - for how to match the above provided labels
+
 # v4.2.0
 * Add flag `set-real-ip-from-header` to specify the name of the request header for the [real ip module](http://nginx.org/en/docs/http/ngx_http_realip_module.html) to use
   * The name of the header will be used by the real ip module in the `set_real_ip_from` directive.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,22 @@ They can be overridden by passing the following arguments during startup.
 A flag `set-real-ip-from-header` can be used to specify the name of the request header for the [real ip module](http://nginx.org/en/docs/http/ngx_http_realip_module.html) to use in the `set_real_ip_from` directive.
 The default value of this flag would be `X-Forwarded-For`
 
+## Namespace selectors
+Namespace selectors can be used for the feed-ingress instance to only process ingress definitions from only those namespaces which have labels matching the ones passed in the input.
+The following 2 flags help facilitate this
+
+1. `ingress-controller-namespace-selectors` - This flag will either be a repeated or comma separated value of namespace labels.
+
+```
+Examples:
+
+1. --ingress-controller-namespace-selectors=app=some-app,team=some-team
+2. --ingress-controller-namespace-selectors=app=some-app --ingress-controller-namespace-selectors=team=some-team
+```
+
+2. `match-all-namespace-selectors` - This flag is to determine how the above flags should be used for matching on the namespace labels. This would be false by default which would mean that a namespace matching any of the above labels will be picked.
+If this flag is set, the namespace on which the ingress is defined should have all of the passed in labels.
+
 ## Ingress status
 When using the [ELB](#elb), [NLB](#nlb) or [Merlin](#merlin) updaters, the ingress status will be updated with relevant
 load balancer information. This can then be used with other controllers such as `external-dns` which can set DNS for any

--- a/feed-ingress/cmd/root.go
+++ b/feed-ingress/cmd/root.go
@@ -45,9 +45,10 @@ var (
 	nginxOpenTracingPluginPath  string
 	nginxOpenTracingConfigPath  string
 
-	ingressClassName        string
-	includeUnnamedIngresses bool
-	namespaceSelector       string
+	ingressClassName           string
+	includeUnnamedIngresses    bool
+	namespaceSelectors         []string
+	matchAllNamespaceSelectors bool
 
 	pushgatewayURL             string
 	pushgatewayIntervalSeconds int
@@ -93,17 +94,16 @@ const (
 	defaultLargeClientHeaderBufferBlocks     = 4
 	defaultSetRealIPFromHeader               = "X-Forwarded-For"
 
-	defaultIngressClassName                   = ""
-	defaultIncludeUnnamedIngresses            = false
-	defaultIngressControllerNamespaceSelector = ""
-
+	defaultIngressClassName           = ""
+	defaultIncludeUnnamedIngresses    = false
 	defaultPushgatewayIntervalSeconds = 60
 )
 
 const (
-	ingressClassFlag                       = "ingress-class"
-	includeClasslessIngressesFlag          = "include-classless-ingresses"
-	ingressControllerNamespaceSelectorFlag = "ingress-controller-namespace-selector"
+	ingressClassFlag                        = "ingress-class"
+	includeClasslessIngressesFlag           = "include-classless-ingresses"
+	ingressControllerNamespaceSelectorsFlag = "ingress-controller-namespace-selectors"
+	matchAllNamespaceSelectorFlags          = "match-all-namespace-selectors"
 
 	ingressClassAnnotation = "kubernetes.io/ingress.class"
 )
@@ -148,8 +148,10 @@ func configureGeneralFlags() {
 		fmt.Sprintf("The name of this instance. It will consider only ingress resources with matching %s annotation values.", ingressClassAnnotation))
 	rootCmd.PersistentFlags().BoolVar(&includeUnnamedIngresses, includeClasslessIngressesFlag, defaultIncludeUnnamedIngresses,
 		fmt.Sprintf("In addition to ingress resources with matching %s annotations, also consider those with no such annotation.", ingressClassAnnotation))
-	rootCmd.PersistentFlags().StringVar(&namespaceSelector, ingressControllerNamespaceSelectorFlag, defaultIngressControllerNamespaceSelector,
-		"Only consider ingresses within namespaces having labels matching this selector (e.g. app=loadtest).")
+	rootCmd.PersistentFlags().StringSliceVar(&namespaceSelectors, ingressControllerNamespaceSelectorsFlag, []string{},
+		"Only consider ingresses within namespaces having labels matching the selectors (e.g. app=loadtest).")
+	rootCmd.PersistentFlags().BoolVar(&matchAllNamespaceSelectors, matchAllNamespaceSelectorFlags, false,
+		fmt.Sprintf("Use only those namespaces containing all the labels passed in %s flag. Default is any i.e or match of labels", ingressControllerNamespaceSelectorsFlag))
 
 	_ = rootCmd.PersistentFlags().MarkDeprecated(includeClasslessIngressesFlag,
 		fmt.Sprintf("please annotate ingress resources explicitly with %s", ingressClassAnnotation))

--- a/util/test/mocks.go
+++ b/util/test/mocks.go
@@ -19,8 +19,8 @@ func (c *FakeClient) GetAllIngresses() ([]*v1beta1.Ingress, error) {
 }
 
 // GetIngresses mocks out calls to GetIngresses
-func (c *FakeClient) GetIngresses(selector *k8s.NamespaceSelector) ([]*v1beta1.Ingress, error) {
-	r := c.Called(selector)
+func (c *FakeClient) GetIngresses(selectors []*k8s.NamespaceSelector, matchAllSelectors bool) ([]*v1beta1.Ingress, error) {
+	r := c.Called(selectors, matchAllSelectors)
 	return r.Get(0).([]*v1beta1.Ingress), r.Error(1)
 }
 


### PR DESCRIPTION
- Remove flag `--ingress-controller-namespace-selector`
- Add flag `--ingress-controller-namespace-selectors` - which can accept comma separated or repeated inputs
- Add flag `--match-all-namespace-selectors` - for how to match the above provided labels