### PR TITLE
Fix bug during feed shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.3.1
+* [BUGFIX] Fix issue with feed not waiting for the drain duration despite having at least one successful call to de-register from the list of registered target groups.
+    * Feed instance can attach to multiple target groups belonging to the load balancer having a tag matching the value in the flag `ingress-class`. The fix is for feed instance to wait for the drain duration even if the de-register call succeeds to at least one of those target groups.
+
 # v4.3.0
 * Provide support for multiple labels for namespace selection
   * Remove flag `--ingress-controller-namespace-selector`

--- a/Makefile
+++ b/Makefile
@@ -101,4 +101,4 @@ endif
 
 check-vulnerabilities:
 	@echo "== Checking for vulnerabilities in the docker image"
-	trivy image --exit-code=1 --severity="HIGH,CRITICAL" $(image_prefix)-ingress:latest
+	trivy image --exit-code=1 --severity="HIGH,CRITICAL" --ignorefile=trivy-ignore-file.txt $(image_prefix)-ingress:latest

--- a/docker/ingress/Dockerfile
+++ b/docker/ingress/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.13
 
 # Install useful diagnostic packages
-RUN apk add --no-cache \
+RUN apk add --upgrade --no-cache \
         libcap \
         curl \
         ca-certificates \

--- a/docker/ingress/Dockerfile
+++ b/docker/ingress/Dockerfile
@@ -1,7 +1,10 @@
 FROM alpine:3.13
 
+# Update list of available packages and upgrade installed packages
+RUN apk -U upgrade
+
 # Install useful diagnostic packages
-RUN apk add --upgrade --no-cache \
+RUN apk add --no-cache \
         libcap \
         curl \
         ca-certificates \

--- a/trivy-ignore-file.txt
+++ b/trivy-ignore-file.txt
@@ -1,0 +1,2 @@
+# The bind-libs version which has this vulnerability fixed is not yet available for alpine. Hence ignoring for now.
+CVE-2020-8625


### PR DESCRIPTION
- Feed instance can attach to multiple target groups belonging to the load balancer having a tag matching the value in the flag `ingress-class`. The fix is for feed instance to wait for the drain duration even if the de-register call succeeds to at least one of those target groups.

closes https://github.com/sky-uk/feed/issues/233