### PR TITLE
validate paths passed to feed

### DIFF
--- a/controller/ingress_entry_test.go
+++ b/controller/ingress_entry_test.go
@@ -158,3 +158,28 @@ func TestNoAllowAddressesResultInNoError(t *testing.T) {
 	// then
 	asserter.NoError(err)
 }
+
+func TestIngressAllowsLegalPath(t *testing.T) {
+	asserter := assert.New(t)
+	e := IngressEntry{
+		Host:           "x",
+		Path:           "/foo",
+		ServiceAddress: "x",
+		ServicePort:    1,
+	}
+	err := e.validate()
+	asserter.NoError(err)
+}
+
+func TestIngressDisallowsPathWithSpace(t *testing.T) {
+	asserter := assert.New(t)
+	e := IngressEntry{
+		Host:           "x",
+		Path:           "/ foo",
+		ServiceAddress: "x",
+		ServicePort:    1,
+	}
+	err := e.validate()
+	asserter.Error(err)
+}
+

--- a/controller/ingress_entry_test.go
+++ b/controller/ingress_entry_test.go
@@ -182,4 +182,3 @@ func TestIngressDisallowsPathWithSpace(t *testing.T) {
 	err := e.validate()
 	asserter.Error(err)
 }
-


### PR DESCRIPTION
k8s does not validate path entries that are part of ingresses, at least
not to the level of stringency that feed expects.  this can lead in some
cases to invalid nginx config being generated due to insufficient
santitzation.  the new approach is to reject paths which donʼt conform
strictly to the rfc 3986 definition of a path.

thanks @jsws for finding this bug