### PR TITLE
Add a readiness endpoint to feed.

### DIFF
--- a/alb/alb.go
+++ b/alb/alb.go
@@ -125,6 +125,9 @@ func (a *alb) Health() error {
 }
 
 func (a *alb) Readiness() error {
+	if !a.readyForHealthCheck.Get() {
+		return errors.New("ALB registration not attempted yet")
+	}
 	return a.Health()
 }
 

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -132,7 +132,7 @@ func (a *alb) Readiness() error {
 }
 
 func (a *alb) String() string {
-	return "ELB frontend"
+	return "ALB frontend"
 }
 
 func (a *alb) attachToFrontEnds() error {

--- a/alb/alb.go
+++ b/alb/alb.go
@@ -124,6 +124,10 @@ func (a *alb) Health() error {
 	return fmt.Errorf("have not attached to all frontends %v yet", a.targetGroupNames)
 }
 
+func (a *alb) Readiness() error {
+	return a.Health()
+}
+
 func (a *alb) String() string {
 	return "ELB frontend"
 }

--- a/alb/alb_test.go
+++ b/alb/alb_test.go
@@ -154,6 +154,7 @@ func TestRegisterInstance(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, updateErr)
 	assert.NoError(t, a.Health())
+	assert.NoError(t, a.Readiness())
 }
 
 func TestReportsErrorIfDidntRegisterAllTargetGroups(t *testing.T) {
@@ -322,6 +323,18 @@ func TestHealthReportsHealthyBeforeFirstUpdate(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	assert.Nil(t, a.Health())
+}
+
+func TestReadinessReportsUnreadyBeforeFirstUpdate(t *testing.T) {
+	// given
+	a, _, _ := setup("internal", "external")
+
+	// when
+	err := a.Start()
+
+	// then
+	assert.NoError(t, err)
+	assert.Error(t, a.Readiness())
 }
 
 func TestHealthReportsUnhealthyAfterUnsuccessfulFirstUpdate(t *testing.T) {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -57,7 +57,7 @@ type Controller interface {
 	Stop() error
 	// Health returns nil for a healthy controller, an error for unhealthy.
 	Health() error
-	// Readiness returns nil for a ready controller, an error for unhealthy.
+	// Readiness returns nil for a ready controller, an error for unready.
 	Readiness() error
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -55,8 +55,10 @@ type Controller interface {
 	Start() error
 	// Stop the controller, blocking until it stops or an error occurs.
 	Stop() error
-	// Healthy returns true for a healthy controller, false for unhealthy.
+	// Health returns nil for a healthy controller, an error for unhealthy.
 	Health() error
+	// Readiness returns nil for a ready controller, an error for unhealthy.
+	Readiness() error
 }
 
 type controller struct {
@@ -449,5 +451,17 @@ func (c *controller) Health() error {
 		return fmt.Errorf("updates failed to apply: %v", err)
 	}
 
+	return nil
+}
+
+func (c *controller) Readiness() error {
+	if err := c.Health(); err != nil {
+		return err
+	}
+	for _, u := range c.updaters {
+		if err := u.Readiness(); err != nil {
+			return fmt.Errorf("%v: %v", u, err)
+		}
+	}
 	return nil
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -50,6 +50,11 @@ func (lb *fakeUpdater) Health() error {
 	return r.Error(0)
 }
 
+func (lb *fakeUpdater) Readiness() error {
+	r := lb.Called()
+	return r.Error(0)
+}
+
 func (lb *fakeUpdater) String() string {
 	return "FakeUpdater"
 }

--- a/controller/updater.go
+++ b/controller/updater.go
@@ -12,4 +12,7 @@ type Updater interface {
 	// Health returns nil if healthy, otherwise an error. Should be fast to respond, as it
 	// may be called often. Any long running checks should be done separately.
 	Health() error
+	// Readiness returns nil if ready, otherwise an error. Should be fast to respond, as it
+	// may be called often. Any long running checks should be done separately.
+	Readiness() error
 }

--- a/dns/dns_updater.go
+++ b/dns/dns_updater.go
@@ -62,6 +62,10 @@ func (u *updater) Health() error {
 	return nil
 }
 
+func (u *updater) Readiness() error {
+	return nil
+}
+
 func (u *updater) Update(entries controller.IngressEntries) error {
 	route53Records, err := u.r53.GetRecords()
 	if err != nil {

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -270,6 +270,10 @@ func (e *elb) Health() error {
 	return fmt.Errorf("expected ELBs: %d actual: %d", e.expectedNumber, e.registeredFrontends.Get())
 }
 
+func (e *elb) Readiness() error {
+	return e.Health()
+}
+
 func (e *elb) Update(controller.IngressEntries) error {
 	e.initialised.Lock()
 	defer e.initialised.Unlock()

--- a/elb/elb.go
+++ b/elb/elb.go
@@ -271,6 +271,9 @@ func (e *elb) Health() error {
 }
 
 func (e *elb) Readiness() error {
+	if !e.readyForHealthCheck.Get() {
+		return errors.New("ELB registration not attempted yet")
+	}
 	return e.Health()
 }
 

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -578,6 +578,18 @@ func TestHealthReportsHealthyBeforeFirstUpdate(t *testing.T) {
 	assert.Nil(t, e.Health())
 }
 
+func TestReadinessReportsUnreadyBeforeFirstUpdate(t *testing.T) {
+	// given
+	e, _, _ := setup()
+
+	// when
+	err := e.Start()
+
+	// then
+	assert.NoError(t, err)
+	assert.Error(t, e.Readiness())
+}
+
 func TestHealthReportsUnhealthyAfterUnsuccessfulFirstUpdate(t *testing.T) {
 	// given
 	e, mockElb, mockMetadata := setup()

--- a/elb/elbstatus/status.go
+++ b/elb/elbstatus/status.go
@@ -69,6 +69,10 @@ func (s *status) Health() error {
 	return nil
 }
 
+func (s *status) Readiness() error {
+	return nil
+}
+
 func (s *status) Update(ingresses controller.IngressEntries) error {
 	return k8sStatus.Update(ingresses, s.loadBalancers, s.kubernetesClient)
 }

--- a/external/status.go
+++ b/external/status.go
@@ -44,6 +44,10 @@ func (s *status) Health() error {
 	return nil
 }
 
+func (s *status) Readiness() error {
+	return nil
+}
+
 func (s *status) Update(ingresses controller.IngressEntries) error {
 	return k8sStatus.Update(ingresses, s.loadBalancers, s.kubernetesClient)
 }

--- a/gorb/gorb.go
+++ b/gorb/gorb.go
@@ -204,6 +204,10 @@ func (g *gorb) Health() error {
 	return nil
 }
 
+func (g *gorb) Readiness() error {
+	return g.Health()
+}
+
 func (g *gorb) Update(controller.IngressEntries) error {
 	var errorArr *multierror.Error
 	if g.config.ManageLoopback {

--- a/merlin/merlin.go
+++ b/merlin/merlin.go
@@ -231,6 +231,10 @@ func (u *updater) Health() error {
 	return nil
 }
 
+func (u *updater) Readiness() error {
+	return nil
+}
+
 func (u *updater) String() string {
 	return "merlin attacher"
 }

--- a/merlin/status/status.go
+++ b/merlin/status/status.go
@@ -58,6 +58,10 @@ func (s *status) Health() error {
 	return nil
 }
 
+func (s *status) Readiness() error {
+	return nil
+}
+
 func (s *status) Update(ingresses controller.IngressEntries) error {
 	return k8sStatus.Update(ingresses, s.loadBalancers, s.kubernetesClient)
 }

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -577,6 +577,10 @@ func (n *nginxUpdater) Health() error {
 	return nil
 }
 
+func (n *nginxUpdater) Readiness() error {
+	return n.Health()
+}
+
 func (n *nginxUpdater) String() string {
 	return "nginx proxy"
 }

--- a/nlb/nlb_test.go
+++ b/nlb/nlb_test.go
@@ -824,3 +824,15 @@ func TestHealthReportsHealthyBeforeFirstUpdate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, elbUpdaterV2.Health())
 }
+
+func TestReadyReportsUnreadyBeforeFirstUpdate(t *testing.T) {
+	// given
+	elbUpdaterV2, _, _ := setup()
+
+	// when
+	err := elbUpdaterV2.Start()
+
+	// then
+	assert.NoError(t, err)
+	assert.Error(t, elbUpdaterV2.Readiness())
+}

--- a/nlb/nlbstatus/status.go
+++ b/nlb/nlbstatus/status.go
@@ -70,6 +70,10 @@ func (s *status) Health() error {
 	return nil
 }
 
+func (s *status) Readiness() error {
+	return nil
+}
+
 func (s *status) Update(ingresses controller.IngressEntries) error {
 	return k8sStatus.Update(ingresses, s.loadBalancers, s.kubernetesClient)
 }


### PR DESCRIPTION
The readiness endpoint calls down to a readiness method on the
controller, just as the healthcheck endpoint does.  The readiness
endpoint is implemented as a loop over all the controllerʼs owned
objects to poll them for readiness.

Most object types implement readiness by just returning the result of
their healthcheck.  The ALB and ELB types keep track of whether they have been registered with AWS, and return that status as their readiness.  The the NLB object type is where interesting things happen.  The AWS docs
call out a situation where it can take “a few minutes” for
healthchecking of an instance registered with a target group to begin.
During this interval, k8s should consider that replica “healthy” (itʼs
registered with the NLB successfully), but not “ready” (itʼs not
receiving traffic).  The distinction matters when doing rolling
deployments.  K8s wonʼt consider a new replica to be fully deployed (and move on with the deployment)
until itʼs ready.  And we donʼt want to treat feed as fully deployed
until it begins receiving traffic from the NLB target group (because we don't want to move on with deploying more replicas until the ones we have deployed are receiving traffic).

This situation has caused several production wobbles for us, where the
premature marking of feed pods as ready leads a rolling deployment to
complete too fast.  In the pessimistic case, we ended up with a brief
interval where there were no live replicas on the NLB at all (because
the old replicas had been torn down, but none of the new ones were out
of their NLB initial healthcheck delay yet).

The readiness logic for NLBs is so far implemented as a simple 5 minute
delay from initial NLB registration to the time when the NLB
controller (and by extension the entire feed process) will be marked as
“ready”.  In the cases weʼve seen, 5 minutes has been a sufficient
delay.  Thereʼs a possible better implementation, whereby we actually
observe whether weʼve received a healthcheck from NLB, and mark
ourselves as ready at the time when that occurs (which could be <5
minutes, leading to more responsive deployments, or could in theory be
\>5 minutes, giving us a safety net if the operational behavior of AWS
NLB changes).  However, thatʼs difficult to implement.  K8s and AWS
healthchecks arrive on the same endpoint.  The NLB controller has no
visibility of the request that is triggering a call to its health
method.  So the mooted implementation would require extensive
refactoring to be able to detect the "healthcheck from NLB" condition
specifically.

This implementation is good enough for now, and the better implementation
can be slotted in if/when it becomes a priority.

Having this implemented in feed itself allows us to avoid the need to
implement workarounds in the deployment yaml of feed in
kubernetes (replicating this implementation with
`initialReadinessDelay`, and not being forward-compatible with any
improvements).  It also moves the problem out of the realm of shadow
knowledge and into the open source implementation.