### PR TITLE
feat(nginx): allow nginx to proxy WebSocket headers

### DIFF
--- a/feed-ingress/cmd/root.go
+++ b/feed-ingress/cmd/root.go
@@ -84,6 +84,7 @@ const (
 	defaultNginxServerNamesHashBucketSize    = unset
 	defaultNginxServerNamesHashMaxSize       = unset
 	defaultNginxProxyProtocol                = false
+	defaultNginxWebsocketUpgrade             = false
 	defaultNginxUpdatePeriod                 = time.Second * 30
 	defaultNginxSSLPath                      = "/etc/ssl/default-ssl/default-ssl"
 	defaultNginxVhostStatsSharedMemory       = 1
@@ -202,6 +203,8 @@ func configureNginxFlags() {
 			"in a separate document. http://nginx.org/en/docs/hash.html")
 	rootCmd.PersistentFlags().BoolVar(&nginxConfig.ProxyProtocol, "nginx-proxy-protocol", defaultNginxProxyProtocol,
 		"Enable PROXY protocol for nginx listeners.")
+	rootCmd.PersistentFlags().BoolVar(&nginxConfig.AllowWebsocketUpgrade, "nginx-allow-websocket-upgrade", defaultNginxWebsocketUpgrade,
+		"Allow Upgrade and Connection headers to be proxied for WebSockets.")
 	rootCmd.PersistentFlags().DurationVar(&nginxConfig.UpdatePeriod, "nginx-update-period", defaultNginxUpdatePeriod,
 		"How often nginx reloads can occur. Too frequent will result in many nginx worker processes alive at the same time.")
 	rootCmd.PersistentFlags().StringVar(&nginxConfig.AccessLogDir, "access-log-dir", defaultAccessLogDir, "Access logs direcoty.")

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -48,6 +48,7 @@ type Conf struct {
 	Ports                        []Port
 	LogLevel                     string
 	ProxyProtocol                bool
+	AllowWebsocketUpgrade        bool
 	AccessLog                    bool
 	AccessLogDir                 string
 	LogHeaders                   []string

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -88,9 +88,22 @@ http {
     # Disable all logging of 404s - to prevent spam when error log is enabled.
     log_not_found off;
 
+{{ if .AllowWebsocketUpgrade }}
+    # Support WebSocket upgrade, allow keepalive
+    # Upgrade logic from http://nginx.org/en/docs/http/websocket.html
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+{{ else }}
     # Enable keepalive to backend.
     proxy_http_version 1.1;
     proxy_set_header Connection "";
+{{ end }}
 
     # Mitigate httpoxy vulnerability.
     proxy_set_header Proxy "";

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -313,6 +313,9 @@ func TestNginxConfig(t *testing.T) {
 	noVhostStatsRequestBucketsConf := defaultConf
 	noVhostStatsRequestBucketsConf.VhostStatsRequestBuckets = nil
 
+	websocketProxyConf := defaultConf
+	websocketProxyConf.AllowWebsocketUpgrade = true
+
 	var tests = []struct {
 		name             string
 		conf             Conf
@@ -521,6 +524,21 @@ func TestNginxConfig(t *testing.T) {
 			noVhostStatsRequestBucketsConf,
 			[]string{
 				"!vhost_traffic_status_histogram_buckets",
+			},
+		},
+		{
+			"WebSocket proxy headers present if enabled",
+			websocketProxyConf,
+			[]string{
+				"# Support WebSocket upgrade, allow keepalive",
+				"# Upgrade logic from http://nginx.org/en/docs/http/websocket.html",
+				"map $http_upgrade $connection_upgrade {",
+				"    default upgrade;",
+				"    ''      '';",
+				"}",
+				"proxy_http_version 1.1;",
+				"proxy_set_header Upgrade $http_upgrade;",
+				"proxy_set_header Connection $connection_upgrade;",
 			},
 		},
 	}


### PR DESCRIPTION
Allows feed to support proxying WebSocket requests if explicitly enabled.

If enabled via the `--nginx-allow-websocket-upgrade` flag, the nginx configuration will be generated with the following block:

```
    # Support WebSocket upgrade, allow keepalive
    # Upgrade logic from http://nginx.org/en/docs/http/websocket.html
    map $http_upgrade $connection_upgrade {
        default upgrade;
        ''      '';
    }

    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection $connection_upgrade;
```

Which will set the `Connection` header to `upgrade` IF the `Upgrade` header is present, otherwise the `proxy_set_header Connection` will be `""` which does not forward, the same as existing feed behaviour.

If the flag is omitted, the nginx config will generate with:

```
    # Enable keepalive to backend.
    proxy_http_version 1.1;
    proxy_set_header Connection "";
```

as it previously did.