### PR TITLE
fix(nginx.tmpl): port_in_redirect off

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -51,6 +51,9 @@ http {
     # Remove the Server header from the response which will have `nginx`
     more_clear_headers Server;
 
+    # When redirecting, such as /prefix -> /prefix/, don't use the internal listen port. Instead, preserve the client port.
+    port_in_redirect off;
+
     {{ if .ClientHeaderBufferSize }}
     # Sets buffer size for reading client request header.
     client_header_buffer_size {{ .ClientHeaderBufferSize }}k;


### PR DESCRIPTION
For locations with a trailing prefix like `/foo/`, nginx will redirect
any requests `/foo` to `/foo/`. By default, it redirects to the internal
listen port which likely will not match the port the external client
uses. Therefore, we should always preserve the external port the client
uses to access ingress.