### PR TITLE
Truncate comment to fit under the line limit for nginx config

### DIFF
--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -160,9 +160,7 @@ http {
 {{ end }}
 
 {{- range $entry := .Servers }}
-    {{ $length := len $entry.Name }}
-    {{- if lt $length 4000 }}# ingress: {{ $entry.Name }}{{ end }}
-    {{- if gt $length 4000 }}# ingress: {{ printf "%.4000s" $entry.Name }}{{ end }}
+    # ingress: {{ printf "%.4000s" $entry.Name }}
   {{- range $portConf := $IngressPorts }}
     server {
         listen {{ $portConf.Port }}{{- if eq $portConf.Name "https" }} ssl{{ end }}{{ if $proxyprotocol }} proxy_protocol{{ end }};

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -160,6 +160,7 @@ http {
 {{ end }}
 
 {{- range $entry := .Servers }}
+    # ingress: {{ printf "%.4000s" $entry.Name }}
   {{- range $portConf := $IngressPorts }}
     server {
         listen {{ $portConf.Port }}{{- if eq $portConf.Name "https" }} ssl{{ end }}{{ if $proxyprotocol }} proxy_protocol{{ end }};

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -160,7 +160,9 @@ http {
 {{ end }}
 
 {{- range $entry := .Servers }}
-    # ingress: {{ $entry.Name }}
+    {{ $length := len $entry.Name }}
+    {{- if lt $length 4000 }}# ingress: {{ $entry.Name }}{{ end }}
+    {{- if gt $length 4000 }}# ingress: {{ printf "%.4000s" $entry.Name }}{{ end }}
   {{- range $portConf := $IngressPorts }}
     server {
         listen {{ $portConf.Port }}{{- if eq $portConf.Name "https" }} ssl{{ end }}{{ if $proxyprotocol }} proxy_protocol{{ end }};

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -160,7 +160,6 @@ http {
 {{ end }}
 
 {{- range $entry := .Servers }}
-    # ingress: {{ printf "%.4000s" $entry.Name }}
   {{- range $portConf := $IngressPorts }}
     server {
         listen {{ $portConf.Port }}{{- if eq $portConf.Name "https" }} ssl{{ end }}{{ if $proxyprotocol }} proxy_protocol{{ end }};

--- a/nginx/nginx.tmpl
+++ b/nginx/nginx.tmpl
@@ -160,6 +160,9 @@ http {
 {{ end }}
 
 {{- range $entry := .Servers }}
+    {{ $strLen := len $entry.Name }} {{ if gt $strLen 4000 }}
+    # The following comment is truncated to 4000 characters due to nginx config line limits
+    {{ end }}
     # ingress: {{ printf "%.4000s" $entry.Name }}
   {{- range $portConf := $IngressPorts }}
     server {


### PR DESCRIPTION
When a large number of ingresses are created, we get into a situation where the line length on the ingresses comment exceeds the maximum allowed for an nginx config line and this stops nginx from starting up.