### PR TITLE
wait for client cache sync: prevents usage of a client that is not ready yet

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -146,19 +146,31 @@ func (c *controller) Start() error {
 		startedUpdaters = append(startedUpdaters, u)
 	}
 
-	c.watchForUpdates()
+	if err := c.watchForUpdates(); err != nil {
+		return err
+	}
 
 	c.started = true
 	return nil
 }
 
-func (c *controller) watchForUpdates() {
+func (c *controller) watchForUpdates() error {
 	ingressWatcher := c.client.WatchIngresses()
+	if ingressWatcher == nil {
+		return fmt.Errorf("ingress watcher not initialized")
+	}
 	serviceWatcher := c.client.WatchServices()
+	if serviceWatcher == nil {
+		return fmt.Errorf("service watcher not initialized")
+	}
 	namespaceWatcher := c.client.WatchNamespaces()
+	if namespaceWatcher == nil {
+		return fmt.Errorf("namespace watcher not initialized")
+	}
 	c.watcher = k8s.CombineWatchers(ingressWatcher, serviceWatcher, namespaceWatcher)
 	c.watcherDone.Add(1)
 	go c.handleUpdates()
+	return nil
 }
 
 func (c *controller) handleUpdates() {

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -215,6 +215,11 @@ func (c *client) createIngressSource() {
 	store, controller := c.informerFactory.createIngressInformer(c.resyncPeriod, watcher)
 	go controller.Run(c.stopCh)
 
+	if !cache.WaitForNamedCacheSync("ingress controller", c.stopCh, controller.HasSynced) {
+		// TODO better return error here
+		return
+	}
+
 	c.ingressWatcher = watcher
 	c.ingressStore = store
 	c.ingressController = controller
@@ -249,6 +254,11 @@ func (c *client) createServiceSource() {
 	store, controller := c.informerFactory.createServiceInformer(c.resyncPeriod, watcher)
 	go controller.Run(c.stopCh)
 
+	if !cache.WaitForNamedCacheSync("service controller", c.stopCh, controller.HasSynced) {
+		// TODO better return error here
+		return
+	}
+
 	c.serviceWatcher = watcher
 	c.serviceStore = store
 	c.serviceController = controller
@@ -269,6 +279,11 @@ func (c *client) createNamespaceSource() {
 	watcher := c.eventHandlerFactory.createBufferedHandler(bufferedWatcherDuration)
 	store, controller := c.informerFactory.createNamespaceInformer(c.resyncPeriod, watcher)
 	go controller.Run(c.stopCh)
+
+	if !cache.WaitForNamedCacheSync("namespace controller", c.stopCh, controller.HasSynced) {
+		// TODO better return error here
+		return
+	}
 
 	c.namespaceWatcher = watcher
 	c.namespaceStore = store

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -216,7 +216,6 @@ func (c *client) createIngressSource() {
 	go controller.Run(c.stopCh)
 
 	if !cache.WaitForNamedCacheSync("ingress controller", c.stopCh, controller.HasSynced) {
-		// TODO better return error here
 		return
 	}
 
@@ -255,7 +254,6 @@ func (c *client) createServiceSource() {
 	go controller.Run(c.stopCh)
 
 	if !cache.WaitForNamedCacheSync("service controller", c.stopCh, controller.HasSynced) {
-		// TODO better return error here
 		return
 	}
 
@@ -281,7 +279,6 @@ func (c *client) createNamespaceSource() {
 	go controller.Run(c.stopCh)
 
 	if !cache.WaitForNamedCacheSync("namespace controller", c.stopCh, controller.HasSynced) {
-		// TODO better return error here
 		return
 	}
 

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Client", func() {
 				fakesController.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 					runExecutedCh <- struct{}{}
 				})
+				fakesController.On("HasSynced").Return(true)
 
 				watcher := clt.WatchIngresses()
 				<-runExecutedCh
@@ -110,6 +111,7 @@ var _ = Describe("Client", func() {
 				fakesController.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 					runExecutedCh <- struct{}{}
 				})
+				fakesController.On("HasSynced").Return(true)
 
 				var waitGroup sync.WaitGroup
 				watchers := &sync.Map{}
@@ -140,6 +142,7 @@ var _ = Describe("Client", func() {
 				fakesController.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 					runExecutedCh <- struct{}{}
 				})
+				fakesController.On("HasSynced").Return(true)
 
 				watcher := clt.WatchServices()
 				<-runExecutedCh
@@ -180,6 +183,7 @@ var _ = Describe("Client", func() {
 				fakesController.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 					runExecutedCh <- struct{}{}
 				})
+				fakesController.On("HasSynced").Return(true)
 
 				var waitGroup sync.WaitGroup
 				watchers := &sync.Map{}
@@ -210,6 +214,7 @@ var _ = Describe("Client", func() {
 				fakesController.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 					runExecutedCh <- struct{}{}
 				})
+				fakesController.On("HasSynced").Return(true)
 
 				watcher := clt.WatchNamespaces()
 				<-runExecutedCh
@@ -250,6 +255,7 @@ var _ = Describe("Client", func() {
 				fakesController.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 					runExecutedCh <- struct{}{}
 				})
+				fakesController.On("HasSynced").Return(true)
 
 				var waitGroup sync.WaitGroup
 				watchers := &sync.Map{}


### PR DESCRIPTION
should fix 

```
[2023-11-23T19:30:59.454Z] time="2023-11-23T17:06:14Z" level=warning msg="Unhealthy: updates failed to apply: ingresses haven't synced yet" source="cmd/cmd.go:89"
```